### PR TITLE
Update .travis.yml to set APPENGINE_DEV_APPSERVER

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ install:
   - mkdir sdk
   - curl -o sdk.zip "https://storage.googleapis.com/appengine-sdks/featured/go_appengine_sdk_linux_amd64-1.9.24.zip"
   - unzip sdk.zip -d sdk
-  - export APPENGINE_DEV_APPSERVER=sdk/go_appengine/dev_appserver.py
+  - export APPENGINE_DEV_APPSERVER=$(pwd)/sdk/go_appengine/dev_appserver.py
 
 script:
   - go version

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ install:
   - mkdir sdk
   - curl -o sdk.zip "https://storage.googleapis.com/appengine-sdks/featured/go_appengine_sdk_linux_amd64-1.9.24.zip"
   - unzip sdk.zip -d sdk
+  - export APPENGINE_DEV_APPSERVER=sdk/go_appengine/dev_appserver.py
 
 script:
   - go version


### PR DESCRIPTION
This makes sure the appengine/aetest tests run with the go tool.