### PR TITLE
Follow symlinks to folders when copying tree

### DIFF
--- a/cmd/aedeploy/aedeploy.go
+++ b/cmd/aedeploy/aedeploy.go
@@ -204,7 +204,7 @@ func copyTree(dstRoot, dstDir, srcDir string) error {
 		}
 		s := filepath.Join(srcDir, n)
 		d := filepath.Join(dstDir, n)
-		if entry.IsDir() {
+		if entry.IsDir() || entry.Mode()&os.ModeSymlink == os.ModeSymlink {
 			if err := copyTree(dstRoot, d, s); err != nil {
 				return fmt.Errorf("unable to copy dir %v to %v: %v", s, d, err)
 			}


### PR DESCRIPTION
If you have a symlink to a directory inside you project folder, it will fail with something similar to:

aedeploy: Error: unable to copy root directory to /app: unable to copy dir sql-ssl to sql-ssl: unable to copy sql-ssl to /var/folders/l9/v_1tf8bj6c54czx4px5pmx580000gn/T/aedeploy750467183/sql-ssl: read sql-ssl: is a directory.

This fixes this error.