### PR TITLE
appengine/cmd/aedeploy: walk non-remote imports

### DIFF
--- a/cmd/aedeploy/aedeploy.go
+++ b/cmd/aedeploy/aedeploy.go
@@ -149,12 +149,12 @@ func imports(ctxt *build.Context, srcDir string, gopath []string) (map[string]st
 	// Resolve all non-standard-library imports
 	result := make(map[string]string)
 	for _, v := range pkg.Imports {
-		if !strings.Contains(v, ".") {
-			continue
-		}
 		src, err := findInGopath(v, gopath)
 		if err != nil {
-			return nil, fmt.Errorf("unable to find import %v in gopath %v: %v", v, gopath, err)
+			// If we cannot find the import, assume that it's part of the
+			// Go standard library, and carry on.  (If it's not, the user
+			// will discover the problem when they try to build the app.)
+			continue
 		}
 		if _, ok := result[src]; ok { // Already processed
 			continue


### PR DESCRIPTION
Prior to this change, aedeploy only included remote imports, making it hard to write a multi-package application without using remote imports.  This change causes aedeploy to include all imports found on the GOPATH, regardless of whether they're remote.