### PR TITLE
Update aedeploy.go

### DIFF
--- a/cmd/aedeploy/aedeploy.go
+++ b/cmd/aedeploy/aedeploy.go
@@ -149,10 +149,10 @@ func imports(ctxt *build.Context, srcDir string, gopath []string) (map[string]st
 	// Resolve all non-standard-library imports
 	result := make(map[string]string)
 	for _, v := range pkg.Imports {
-		if !strings.Contains(v, ".") {
+		src, err := findInGopath(v, gopath)
+		if err != nil && !strings.Contains(v, ".") {
 			continue
 		}
-		src, err := findInGopath(v, gopath)
 		if err != nil {
 			return nil, fmt.Errorf("unable to find import %v in gopath %v: %v", v, gopath, err)
 		}


### PR DESCRIPTION
Maybe not what you want, but I had some helpers in my gopath that didn't have a . in them (which assumes the packages must be hosted?).  Spent an hour or so until I realized exactly what was happening, so figured I might toss the fix back...

Having said this, I understand what your doing and maybe I simply had a unique edge case :P