### PR TITLE
Remove preview from gcloud in aedeploy help string

### DIFF
--- a/cmd/aedeploy/aedeploy.go
+++ b/cmd/aedeploy/aedeploy.go
@@ -38,7 +38,7 @@ var (
 
 func usage() {
 	fmt.Fprintf(os.Stderr, "Usage of %s:\n", os.Args[0])
-	fmt.Fprintf(os.Stderr, "\t%s gcloud --verbosity debug preview app deploy --version myversion ./app.yaml\tDeploy app to production\n", os.Args[0])
+	fmt.Fprintf(os.Stderr, "\t%s gcloud --verbosity debug app deploy --version myversion ./app.yaml\tDeploy app to production\n", os.Args[0])
 }
 
 func main() {


### PR DESCRIPTION
Pretty sure we shouldn't have the preview there anymore?
