### PR TITLE
aetest/instance_vm.go: Fix race in Close()

### DIFF
--- a/aetest/instance_vm.go
+++ b/aetest/instance_vm.go
@@ -92,8 +92,9 @@ func (i *instance) Close() (err error) {
 
 	if p := i.child.Process; p != nil {
 		errc := make(chan error, 1)
+		child := i.child // copy to avoid race with deferred func assigning nil
 		go func() {
-			errc <- i.child.Wait()
+			errc <- child.Wait()
 		}()
 
 		// Call the quit handler on the admin server.


### PR DESCRIPTION
Close starts a goroutine to read from the child process i.child. When
Close finishes, a deferred func assigns i.child = nil. These statements
race. The easy fix is to copy i.child to a local variable so it will be
included in the closure.

Fixes issue #26

Race detector output:

```
WARNING: DATA RACE
Write by goroutine 9:
  google.golang.org/appengine/aetest.(*instance).Close.func1()
      /home/ubuntu/.go_workspace/src/google.golang.org/appengine/aetest/instance_vm.go:86 +0x37
  google.golang.org/appengine/aetest.(*instance).Close()
      /home/ubuntu/.go_workspace/src/google.golang.org/appengine/aetest/instance_vm.go:110 +0x5ee
... application ...
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:473 +0xdc

Previous read by goroutine 22:
  google.golang.org/appengine/aetest.(*instance).Close.func2()
      /home/ubuntu/.go_workspace/src/google.golang.org/appengine/aetest/instance_vm.go:96 +0x33

Goroutine 9 (running) created at:
  testing.RunTests()
      /usr/local/go/src/testing/testing.go:582 +0xae2
  testing.(*M).Run()
      /usr/local/go/src/testing/testing.go:515 +0x11d
  main.main()

Goroutine 22 (running) created at:
  google.golang.org/appengine/aetest.(*instance).Close()
      /home/ubuntu/.go_workspace/src/google.golang.org/appengine/aetest/instance_vm.go:97 +0x23e
... application ...
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:473 +0xdc
```