### PR TITLE
LICENSE: Fix license boilerplate

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2016 Google, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
The bottom of the LICENSE field is the part that you are supposed to copy when
you include this code in other projects. It would be good for it to say
"Google, Inc" instead of "[copyright year] [copyright holder]."