### PR TITLE
main_vm.go: Listen on localhost for dev_appserver; Avoid Mac Firewall

### DIFF
--- a/internal/main_vm.go
+++ b/internal/main_vm.go
@@ -22,7 +22,11 @@ func Main() {
 		port = s
 	}
 
-	if err := http.ListenAndServe(":"+port, http.HandlerFunc(handleHTTP)); err != nil {
+	host := ""
+	if IsDevAppServer() {
+		host = "127.0.0.1"
+	}
+	if err := http.ListenAndServe(host+":"+port, http.HandlerFunc(handleHTTP)); err != nil {
 		log.Fatalf("http.ListenAndServe: %v", err)
 	}
 }


### PR DESCRIPTION
Without this, the Mac OS X firewall asks if _ah_exe should accept
incoming network connections, since by default it listens on all
interfaces. For development purposes, it is sufficient to only listen
on localhost.