### PR TITLE
internal: adjust memory threshold for API test

### DIFF
--- a/internal/api_test.go
+++ b/internal/api_test.go
@@ -381,7 +381,7 @@ func TestAPICallAllocations(t *testing.T) {
 
 	// Lots of room for improvement...
 	// TODO(djd): Reduce maximum to 85 once the App Engine SDK is based on 1.6.
-	const min, max float64 = 70, 90
+	const min, max float64 = 70, 100
 	if avg < min || max < avg {
 		t.Errorf("Allocations per API call = %g, want in [%g,%g]", avg, min, max)
 	}


### PR DESCRIPTION
There are some major protobuf performance optimizations at work that
improve runtime performance of protobuf, but due to the lack of
batching in the current approach, memory usage will be slightly higher.
This will be eventually fixed.

Adjust the thresholds here to avoid failing the test.

\cc @shantuo @randall77