### PR TITLE
Switch google_appengine to google-appengine.

### DIFF
--- a/cmd/aebundler/aebundler.go
+++ b/cmd/aebundler/aebundler.go
@@ -8,7 +8,7 @@
 // A main func is synthesized if one does not exist.
 //
 // A sample Dockerfile to be used with this bundler could look like this:
-//     FROM gcr.io/google_appengine/go-compat
+//     FROM gcr.io/google-appengine/go-compat
 //     ADD . /app
 //     RUN GOPATH=/app/_gopath go build -tags appenginevm -o /app/_ah/exe
 package main


### PR DESCRIPTION
These are equivalent, but GCR would like to encourage users to switch to
the hyphen form.