### PR TITLE
datastore: implement "omitempty" struct field tag option

### DIFF
--- a/datastore/datastore_test.go
+++ b/datastore/datastore_test.go
@@ -134,6 +134,37 @@ type K1 struct {
 	K []*Key
 }
 
+type S struct {
+	St string
+}
+
+type NoOmit struct {
+	A string
+	B int  `datastore:"Bb"`
+	C bool `datastore:",noindex"`
+}
+
+type OmitAll struct {
+	A string `datastore:",omitempty"`
+	B int    `datastore:"Bb,omitempty"`
+	C bool   `datastore:",omitempty,noindex"`
+	F []int  `datastore:",omitempty"`
+}
+
+type Omit struct {
+	A string `datastore:",omitempty"`
+	B int    `datastore:"Bb,omitempty"`
+	C bool   `datastore:",omitempty,noindex"`
+	F []int  `datastore:",omitempty"`
+	S `datastore:",omitempty"`
+}
+
+type NoOmits struct {
+	No []NoOmit `datastore:",omitempty"`
+	S  `datastore:",omitempty"`
+	Ss S `datastore:",omitempty"`
+}
+
 type N0 struct {
 	X0
 	Nonymous X0
@@ -482,6 +513,77 @@ var testCases = []testCase{
 		"geopoint slice",
 		&G1{G: []appengine.GeoPoint{testGeoPt0, testGeoPt1}},
 		&G1{G: []appengine.GeoPoint{testGeoPt0, testGeoPt1}},
+		"",
+		"",
+	},
+	{
+		"omit empty, all",
+		&OmitAll{},
+		new(PropertyList),
+		"",
+		"",
+	},
+	{
+		"omit empty",
+		&Omit{},
+		&PropertyList{
+			Property{Name: "St", Value: "", NoIndex: false, Multiple: false},
+		},
+		"",
+		"",
+	},
+	{
+		"omit empty, fields populated",
+		&Omit{
+			A: "a",
+			B: 10,
+			C: true,
+			F: []int{11},
+		},
+		&PropertyList{
+			Property{Name: "A", Value: "a", NoIndex: false, Multiple: false},
+			Property{Name: "Bb", Value: int64(10), NoIndex: false, Multiple: false},
+			Property{Name: "C", Value: true, NoIndex: true, Multiple: false},
+			Property{Name: "F", Value: int64(11), NoIndex: false, Multiple: true},
+			Property{Name: "St", Value: "", NoIndex: false, Multiple: false},
+		},
+		"",
+		"",
+	},
+	{
+		"omit empty, fields populated",
+		&Omit{
+			A: "a",
+			B: 10,
+			C: true,
+			F: []int{11},
+			S: S{St: "string"},
+		},
+		&PropertyList{
+			Property{Name: "A", Value: "a", NoIndex: false, Multiple: false},
+			Property{Name: "Bb", Value: int64(10), NoIndex: false, Multiple: false},
+			Property{Name: "C", Value: true, NoIndex: true, Multiple: false},
+			Property{Name: "F", Value: int64(11), NoIndex: false, Multiple: true},
+			Property{Name: "St", Value: "string", NoIndex: false, Multiple: false},
+		},
+		"",
+		"",
+	},
+	{
+		"omit empty does not propagate",
+		&NoOmits{
+			No: []NoOmit{
+				NoOmit{},
+			},
+			S:  S{},
+			Ss: S{},
+		},
+		&PropertyList{
+			Property{Name: "No.A", Value: "", NoIndex: false, Multiple: true},
+			Property{Name: "No.Bb", Value: int64(0), NoIndex: false, Multiple: true},
+			Property{Name: "No.C", Value: false, NoIndex: true, Multiple: true},
+			Property{Name: "Ss.St", Value: "", NoIndex: false, Multiple: false},
+			Property{Name: "St", Value: "", NoIndex: false, Multiple: false}},
 		"",
 		"",
 	},

--- a/datastore/doc.go
+++ b/datastore/doc.go
@@ -87,7 +87,7 @@ behavior for struct pointers. Struct pointers are more strongly typed and are
 easier to use; PropertyLoadSavers are more flexible.
 
 The actual types passed do not have to match between Get and Put calls or even
-across different App Engine requests. It is valid to put a *PropertyList and
+across different calls to datastore. It is valid to put a *PropertyList and
 get that same entity as a *myStruct, or put a *myStruct0 and get a *myStruct1.
 Conceptually, any entity is saved as a sequence of properties, and is loaded
 into the destination value on a property-by-property basis. When loading into
@@ -97,18 +97,28 @@ caller whether this error is fatal, recoverable or ignorable.
 
 By default, for struct pointers, all properties are potentially indexed, and
 the property name is the same as the field name (and hence must start with an
-upper case letter). Fields may have a `datastore:"name,options"` tag. The tag
-name is the property name, which must be one or more valid Go identifiers
-joined by ".", but may start with a lower case letter. An empty tag name means
-to just use the field name. A "-" tag name means that the datastore will
-ignore that field. If options is "noindex" then the field will not be indexed.
-If the options is "" then the comma may be omitted. There are no other
-recognized options.
+upper case letter).
 
-Fields (except for []byte) are indexed by default. Strings longer than 1500
-bytes cannot be indexed; fields used to store long strings should be
-tagged with "noindex". Similarly, ByteStrings longer than 1500 bytes cannot be
-indexed.
+Fields may have a `datastore:"name,options"` tag. The tag name is the
+property name, which must be one or more valid Go identifiers joined by ".",
+but may start with a lower case letter. An empty tag name means to just use the
+field name. A "-" tag name means that the datastore will ignore that field.
+
+The only valid options are "omitempty" and "noindex".
+
+If the options include "omitempty" and the value of the field is empty, then the field will be omitted on Save.
+The empty values are false, 0, any nil interface value, and any array, slice, map, or string of length zero.
+Struct field values will never be empty.
+
+If options include "noindex" then the field will not be indexed. All fields are indexed
+by default. Strings or byte slices longer than 1500 bytes cannot be indexed;
+fields used to store long strings and byte slices must be tagged with "noindex"
+or they will cause Put operations to fail.
+
+To use multiple options together, separate them by a comma.
+The order does not matter.
+
+If the options is "" then the comma may be omitted.
 
 Example code:
 

--- a/datastore/prop.go
+++ b/datastore/prop.go
@@ -150,6 +150,9 @@ type fieldCodec struct {
 	// path is the index path to the field
 	path    []int
 	noIndex bool
+	// omitEmpty indicates that the field should be omitted on save
+	// if empty.
+	omitEmpty bool
 	// structCodec is the codec fot the struct field at index 'path',
 	// or nil if the field is not a struct.
 	structCodec *structCodec
@@ -261,6 +264,7 @@ func getStructCodecLocked(t reflect.Type) (ret *structCodec, retErr error) {
 					c.fields[subname] = fieldCodec{
 						path:        append([]int{i}, subfield.path...),
 						noIndex:     subfield.noIndex || opts["noindex"],
+						omitEmpty:   subfield.omitEmpty,
 						structCodec: subfield.structCodec,
 					}
 				}
@@ -274,6 +278,7 @@ func getStructCodecLocked(t reflect.Type) (ret *structCodec, retErr error) {
 		c.fields[name] = fieldCodec{
 			path:        []int{i},
 			noIndex:     opts["noindex"],
+			omitEmpty:   opts["omitempty"],
 			structCodec: sub,
 		}
 	}

--- a/datastore/save.go
+++ b/datastore/save.go
@@ -111,6 +111,12 @@ func valueToProto(defaultAppID, name string, v reflect.Value, multiple bool) (p 
 	return p, ""
 }
 
+type saveOpts struct {
+	noIndex   bool
+	multiple  bool
+	omitEmpty bool
+}
+
 // saveEntity saves an EntityProto into a PropertyLoadSaver or struct pointer.
 func saveEntity(defaultAppID string, key *Key, src interface{}) (*pb.EntityProto, error) {
 	var err error
@@ -126,11 +132,14 @@ func saveEntity(defaultAppID string, key *Key, src interface{}) (*pb.EntityProto
 	return propertiesToProto(defaultAppID, key, props)
 }
 
-func saveStructProperty(props *[]Property, name string, noIndex, multiple bool, v reflect.Value) error {
+func saveStructProperty(props *[]Property, name string, opts saveOpts, v reflect.Value) error {
+	if opts.omitEmpty && isEmptyValue(v) {
+		return nil
+	}
 	p := Property{
 		Name:     name,
-		NoIndex:  noIndex,
-		Multiple: multiple,
+		NoIndex:  opts.noIndex,
+		Multiple: opts.multiple,
 	}
 	switch x := v.Interface().(type) {
 	case *Key:
@@ -166,7 +175,7 @@ func saveStructProperty(props *[]Property, name string, noIndex, multiple bool, 
 			if err != nil {
 				return fmt.Errorf("datastore: unsupported struct field: %v", err)
 			}
-			return sub.save(props, name+".", noIndex, multiple)
+			return sub.save(props, name+".", opts)
 		}
 	}
 	if p.Value == nil {
@@ -178,31 +187,35 @@ func saveStructProperty(props *[]Property, name string, noIndex, multiple bool, 
 
 func (s structPLS) Save() ([]Property, error) {
 	var props []Property
-	if err := s.save(&props, "", false, false); err != nil {
+	if err := s.save(&props, "", saveOpts{}); err != nil {
 		return nil, err
 	}
 	return props, nil
 }
 
-func (s structPLS) save(props *[]Property, prefix string, noIndex, multiple bool) error {
+func (s structPLS) save(props *[]Property, prefix string, opts saveOpts) error {
 	for name, f := range s.codec.fields {
 		name = prefix + name
 		v := s.v.FieldByIndex(f.path)
 		if !v.IsValid() || !v.CanSet() {
 			continue
 		}
-		noIndex1 := noIndex || f.noIndex
+		var opts1 saveOpts
+		opts1.noIndex = opts.noIndex || f.noIndex
+		opts1.multiple = opts.multiple
+		opts1.omitEmpty = f.omitEmpty // don't propagate
 		// For slice fields that aren't []byte, save each element.
 		if v.Kind() == reflect.Slice && v.Type().Elem().Kind() != reflect.Uint8 {
+			opts1.multiple = true
 			for j := 0; j < v.Len(); j++ {
-				if err := saveStructProperty(props, name, noIndex1, true, v.Index(j)); err != nil {
+				if err := saveStructProperty(props, name, opts1, v.Index(j)); err != nil {
 					return err
 				}
 			}
 			continue
 		}
 		// Otherwise, save the field itself.
-		if err := saveStructProperty(props, name, noIndex1, multiple, v); err != nil {
+		if err := saveStructProperty(props, name, opts1, v); err != nil {
 			return err
 		}
 	}
@@ -291,4 +304,24 @@ func propertiesToProto(defaultAppID string, key *Key, props []Property) (*pb.Ent
 		}
 	}
 	return e, nil
+}
+
+// isEmptyValue is taken from the encoding/json package in the
+// standard library.
+func isEmptyValue(v reflect.Value) bool {
+	switch v.Kind() {
+	case reflect.Array, reflect.Map, reflect.Slice, reflect.String:
+		return v.Len() == 0
+	case reflect.Bool:
+		return !v.Bool()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return v.Int() == 0
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return v.Uint() == 0
+	case reflect.Float32, reflect.Float64:
+		return v.Float() == 0
+	case reflect.Interface, reflect.Ptr:
+		return v.IsNil()
+	}
+	return false
 }


### PR DESCRIPTION
The datastore "omitempty" option behaves identically to "omitempty"
in the standard library's encoding/json.

This change is almost identical to https://github.com/GoogleCloudPlatform/google-cloud-go/commit/94f177402d59546c5639e015376f04a6a92b02

Fixes #38