### PR TITLE
aetest: add StartupTimeout option

### DIFF
--- a/aetest/instance.go
+++ b/aetest/instance.go
@@ -3,6 +3,7 @@ package aetest
 import (
 	"io"
 	"net/http"
+	"time"
 
 	"golang.org/x/net/context"
 	"google.golang.org/appengine"
@@ -24,6 +25,9 @@ type Options struct {
 	// StronglyConsistentDatastore is whether the local datastore should be
 	// strongly consistent. This will diverge from production behaviour.
 	StronglyConsistentDatastore bool
+	// StartupTimeout is a duration to wait for instance startup.
+	// By default, 15 seconds.
+	StartupTimeout time.Duration
 }
 
 // NewContext starts an instance of the development API server, and returns


### PR DESCRIPTION
In congested test environments it's not uncommon to have 5-30 second
delays. This often results in test flackyness when child startup is
delayed above hardcoded 15 seconds.

This patch allows to pass timeout as an option so it can be configured
specifically for target test environment.