### PR TITLE
datastore: fix handling of embedded unexported structs

### DIFF
--- a/datastore/prop_test.go
+++ b/datastore/prop_test.go
@@ -97,6 +97,7 @@ func TestStructCodec(t *testing.T) {
 			"R": {path: []int{0}},
 			"S": {path: []int{1}, structCodec: pStructCodec},
 			"T": {path: []int{2}, structCodec: oStructCodec},
+			"O": {path: []int{3, 0}},
 		},
 		complete: true,
 	}
@@ -209,6 +210,7 @@ func TestStructCodec(t *testing.T) {
 					"B":   {path: []int{1}},
 					"CC":  {path: []int{2}, structCodec: oStructCodec},
 					"DDD": {path: []int{3}, structCodec: rStructCodec},
+					"O":   {path: []int{4, 0}},
 				},
 				complete: true,
 			},
@@ -224,9 +226,10 @@ func TestStructCodec(t *testing.T) {
 			}{},
 			&structCodec{
 				fields: map[string]fieldCodec{
-					"w":  {path: []int{1}},
-					"xx": {path: []int{2}, structCodec: oStructCodec},
-					"y":  {path: []int{3}, structCodec: rStructCodec},
+					"w":   {path: []int{1}},
+					"xx":  {path: []int{2}, structCodec: oStructCodec},
+					"y":   {path: []int{3}, structCodec: rStructCodec},
+					"z.O": {path: []int{4, 0}},
 				},
 				complete: true,
 			},
@@ -244,6 +247,7 @@ func TestStructCodec(t *testing.T) {
 				fields: map[string]fieldCodec{
 					"B": {path: []int{1}},
 					"D": {path: []int{3}, structCodec: uStructCodec},
+					"U": {path: []int{4, 0}},
 				},
 				complete: true,
 			},


### PR DESCRIPTION
This PR fixes the handling of embedded unexported structs, as discussed in #54.

This functionality existed for years, even predating this package. It was broken due to inaction. Starting from 1.9.35 (March 2016) the Go SDK is based on Go 1.6. The [Go 1.6 release notes](https://golang.org/doc/go1.6#reflect) are explicit in mentioning that packages that use `reflect` need to be updated to keep functional equivalence.