### PR TITLE
README: update for flex beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,7 @@
 
 [![Build Status](https://travis-ci.org/golang/appengine.svg)](https://travis-ci.org/golang/appengine)
 
-This repository supports the Go runtime on App Engine,
-including both the standard App Engine and the
-"App Engine flexible environment" (formerly known as "Managed VMs").
+This repository supports the Go runtime on *App Engine standard*.
 It provides APIs for interacting with App Engine services.
 Its canonical import path is `google.golang.org/appengine`.
 
@@ -13,6 +11,15 @@ for more information.
 
 File issue reports and feature requests on the [GitHub's issue
 tracker](https://github.com/golang/appengine/issues).
+
+## Upgrading an App Engine app to the flexible environment
+
+This package does not work on *App Engine flexible*.
+
+There are many differences between the App Engine standard environment and
+the flexible environment.
+
+See the [documentation on upgrading to the flexible environment](https://cloud.google.com/appengine/docs/flexible/go/upgrading).
 
 ## Directory structure
 
@@ -24,13 +31,6 @@ packages are in subdirectories (e.g. `datastore`).
 There is an `internal` subdirectory that contains service protocol buffers,
 plus packages required for connectivity to make API calls. App Engine apps
 should not directly import any package under `internal`.
-
-## Upgrading an App Engine app to the flexible environment
-
-There are many differences between the App Engine standard environment and
-the flexible environment.
-
-See the [documentation on upgrading to the flexible environment](https://cloud.google.com/appengine/docs/flexible/go/upgrading).
 
 ## Updating from legacy (`import "appengine"`) packages
 

--- a/README.md
+++ b/README.md
@@ -11,10 +11,11 @@ Its canonical import path is `google.golang.org/appengine`.
 See https://cloud.google.com/appengine/docs/go/
 for more information.
 
-File issue reports and feature requests on the [Google App Engine issue
-tracker](https://code.google.com/p/googleappengine/issues/entry?template=Go%20defect).
+File issue reports and feature requests on the [GitHub's issue
+tracker](https://github.com/golang/appengine/issues).
 
 ## Directory structure
+
 The top level directory of this repository is the `appengine` package. It
 contains the
 basic APIs (e.g. `appengine.NewContext`) that apply across APIs. Specific API
@@ -24,32 +25,31 @@ There is an `internal` subdirectory that contains service protocol buffers,
 plus packages required for connectivity to make API calls. App Engine apps
 should not directly import any package under `internal`.
 
-## Updating a Go App Engine app
+## Upgrading an App Engine app to the flexible environment
 
-This section describes how to update an older Go App Engine app to use
-these packages. A provided tool, `aefix`, can help automate steps 2 and 3
-(run `go get google.golang.org/appengine/cmd/aefix` to install it), but
-read the details below since `aefix` can't perform all the changes.
+There are many differences between the App Engine standard environment and
+the flexible environment.
 
-### 1. Update YAML files (App Engine flexible environment / Managed VMs only)
+See the [documentation on upgrading to the flexible environment](https://cloud.google.com/appengine/docs/flexible/go/upgrading).
 
-The `app.yaml` file (and YAML files for modules) should have these new lines added:
-```
-vm: true
-```
-See https://cloud.google.com/appengine/docs/go/modules/#Go_Instance_scaling_and_class for details.
+## Updating from legacy (`import "appengine"`) packages
 
-### 2. Update import paths
+If you're currently using the bare `appengine` packages
+(that is, not these ones, imported via `google.golang.org/appengine`),
+then you can use the `aefix` tool to help automate an upgrade to these packages.
+
+Run `go get google.golang.org/appengine/cmd/aefix` to install it.
+
+### 1. Update import paths
 
 The import paths for App Engine packages are now fully qualified, based at `google.golang.org/appengine`.
 You will need to update your code to use import paths starting with that; for instance,
 code importing `appengine/datastore` will now need to import `google.golang.org/appengine/datastore`.
 
-### 3. Update code using deprecated, removed or modified APIs
+### 2. Update code using deprecated, removed or modified APIs
 
 Most App Engine services are available with exactly the same API.
-A few APIs were cleaned up, and some are not available yet.
-This list summarises the differences:
+A few APIs were cleaned up, and there are some differences:
 
 * `appengine.Context` has been replaced with the `Context` type from `golang.org/x/net/context`.
 * Logging methods that were on `appengine.Context` are now functions in `google.golang.org/appengine/log`.


### PR DESCRIPTION
The Flex ("Beta 2") environment does not support many of the App Engine APIs.

Add a section pointing those people toward the upgrade guide on cloud.google.com.

Retain the existing section about aefix, but remove the suggestion that it's useful with the flexible environment.