### PR TITLE
user: check for valid context and panic if not

### DIFF
--- a/user/user_classic.go
+++ b/user/user_classic.go
@@ -35,5 +35,10 @@ func Current(ctx context.Context) *User {
 }
 
 func IsAdmin(ctx context.Context) bool {
-	return user.IsAdmin(internal.ClassicContextFromContext(ctx))
+	c, err := internal.ClassicContextFromContext(ctx)
+	if err != nil {
+		panic(err)
+	}
+
+	return user.IsAdmin(c)
 }


### PR DESCRIPTION
This call to ClassicContextFromContext was missed in eda0abe.