### PR TITLE
travis: properly test pull requests, rather than always testing tip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,17 +2,22 @@ language: go
 
 go:
   - 1.6.3
-  - 1.7.1
+  - 1.7.5
+  - 1.8.1
+
+go_import_path: google.golang.org/appengine
 
 install:
-  - go get -v -t -d google.golang.org/appengine/...
-  - mkdir sdk
-  - curl -o sdk.zip "https://storage.googleapis.com/appengine-sdks/featured/go_appengine_sdk_linux_amd64-1.9.40.zip"
-  - unzip -q sdk.zip -d sdk
-  - export APPENGINE_DEV_APPSERVER=$(pwd)/sdk/go_appengine/dev_appserver.py
+  - go get -u -v $(go list -f '{{join .Imports "\n"}}{{"\n"}}{{join .TestImports "\n"}}' ./... | sort | uniq | grep -v appengine)
+  - mkdir /tmp/sdk
+  - curl -o /tmp/sdk.zip "https://storage.googleapis.com/appengine-sdks/featured/go_appengine_sdk_linux_amd64-1.9.40.zip"
+  - unzip -q /tmp/sdk.zip -d /tmp/sdk
+  - export PATH="$PATH:/tmp/sdk/go_appengine"
+  - export APPENGINE_DEV_APPSERVER=/tmp/sdk/go_appengine/dev_appserver.py
 
 script:
+  - goapp version
   - go version
   - go test -v google.golang.org/appengine/...
   - go test -v -race google.golang.org/appengine/...
-  - sdk/go_appengine/goapp test -v google.golang.org/appengine/...
+  - goapp test -v google.golang.org/appengine/...


### PR DESCRIPTION
Previously, the travis build would pull from master/HEAD, rather than
from the commit of the pull requests, rendering presubmit tests useless.

Use go_import_path to ensure that HEAD from the pull request is used
instead, and selectively "go get" the other dependencies.