### PR TITLE
datastore: Add Key creation functions

### DIFF
--- a/datastore/key.go
+++ b/datastore/key.go
@@ -271,6 +271,18 @@ func NewKey(c context.Context, kind, stringID string, intID int64, parent *Key) 
 	}
 }
 
+// NameKey creates a new key with a name.
+// The supplied kind cannot be empty.
+func NameKey(c context.Context, kind, name string, parent *Key) *Key {
+	return NewKey(c, kind, name, 0, parent)
+}
+
+// IDKey creates a new key with an ID.
+// The supplied kind cannot be empty.
+func IDKey(c context.Context, kind string, id int64, parent *Key) *Key {
+	return NewKey(c, kind, "", id, parent)
+}
+
 // AllocateIDs returns a range of n integer IDs with the given kind and parent
 // combination. kind cannot be empty; parent may be nil. The IDs in the range
 // returned will not be used by the datastore's automatic ID sequence generator

--- a/datastore/key.go
+++ b/datastore/key.go
@@ -273,7 +273,7 @@ func NewKey(c context.Context, kind, stringID string, intID int64, parent *Key) 
 
 // NameKey creates a new key with a name.
 // The supplied kind cannot be empty.
-func NameKey(c context.Context, kind, name string, parent *Key) *Key {
+func NameKey(c context.Context, kind string, name string, parent *Key) *Key {
 	return NewKey(c, kind, name, 0, parent)
 }
 


### PR DESCRIPTION
I think these two key creation functions: the NameKey and IDKey will 1) add more simplicity for people who want to use this library and create keys that already exist, but also 2) will have greater compatibility for people switching between this library and the Google Cloud for Go library. Thanks!