### PR TITLE
log: clarify package docs

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -3,8 +3,8 @@
 // license that can be found in the LICENSE file.
 
 /*
-Package log provides the means of querying an application's logs from
-within an App Engine application.
+Package log provides the means of writing and querying an application's logs
+from within an App Engine application.
 
 Example:
 	c := appengine.NewContext(r)


### PR DESCRIPTION
The package docs can be interpreted as: "this package is only for
querying the logs". Unless reader looks at actual func names, it's not
obvious they can actually write the logs as well.

It would be nice to mention this package in any of the tutorials as
well, since stderr output just disappears.