### PR TITLE
remote_api: add long-lived Client type

### DIFF
--- a/remote_api/client.go
+++ b/remote_api/client.go
@@ -27,10 +27,16 @@ import (
 	pb "google.golang.org/appengine/internal/remote_api"
 )
 
-// NewRemoteContext returns a context that gives access to the production
-// APIs for the application at the given host. All communication will be
-// performed over SSL unless the host is localhost.
-func NewRemoteContext(host string, client *http.Client) (context.Context, error) {
+// Client is a connection to the production APIs for an application.
+type Client struct {
+	hc    *http.Client
+	url   string
+	appID string
+}
+
+// NewClient returns a client for the given host. All communication will
+// be performed over SSL unless the host is localhost.
+func NewClient(host string, client *http.Client) (*Client, error) {
 	// Add an appcfg header to outgoing requests.
 	t := client.Transport
 	if t == nil {
@@ -51,19 +57,31 @@ func NewRemoteContext(host string, client *http.Client) (context.Context, error)
 	if err != nil {
 		return nil, fmt.Errorf("unable to contact server: %v", err)
 	}
-	rc := &remoteContext{
-		client: client,
-		url:    u,
-	}
-	ctx := internal.WithCallOverride(context.Background(), rc.call)
-	ctx = internal.WithLogOverride(ctx, rc.logf)
-	ctx = internal.WithAppIDOverride(ctx, appID)
-	return ctx, nil
+	return &Client{
+		hc:    client,
+		url:   u,
+		appID: appID,
+	}, nil
 }
 
-type remoteContext struct {
-	client *http.Client
-	url    string
+// NewContext returns a copy of parent that will cause App Engine API
+// calls to be sent to the client's remote host.
+func (c *Client) NewContext(parent context.Context) context.Context {
+	ctx := internal.WithCallOverride(parent, c.call)
+	ctx = internal.WithLogOverride(ctx, c.logf)
+	ctx = internal.WithAppIDOverride(ctx, c.appID)
+	return ctx
+}
+
+// NewRemoteContext returns a context that gives access to the production
+// APIs for the application at the given host. All communication will be
+// performed over SSL unless the host is localhost.
+func NewRemoteContext(host string, client *http.Client) (context.Context, error) {
+	c, err := NewClient(host, client)
+	if err != nil {
+		return nil, err
+	}
+	return c.NewContext(context.Background()), nil
 }
 
 var logLevels = map[int64]string{
@@ -74,11 +92,11 @@ var logLevels = map[int64]string{
 	4: "CRITICAL",
 }
 
-func (c *remoteContext) logf(level int64, format string, args ...interface{}) {
+func (c *Client) logf(level int64, format string, args ...interface{}) {
 	log.Printf(logLevels[level]+": "+format, args...)
 }
 
-func (c *remoteContext) call(ctx context.Context, service, method string, in, out proto.Message) error {
+func (c *Client) call(ctx context.Context, service, method string, in, out proto.Message) error {
 	req, err := proto.Marshal(in)
 	if err != nil {
 		return fmt.Errorf("error marshalling request: %v", err)
@@ -97,7 +115,7 @@ func (c *remoteContext) call(ctx context.Context, service, method string, in, ou
 	}
 
 	// TODO(djd): Respect ctx.Deadline()?
-	resp, err := c.client.Post(c.url, "application/octet-stream", bytes.NewReader(req))
+	resp, err := c.hc.Post(c.url, "application/octet-stream", bytes.NewReader(req))
 	if err != nil {
 		return fmt.Errorf("error sending request: %v", err)
 	}

--- a/remote_api/client_test.go
+++ b/remote_api/client_test.go
@@ -5,7 +5,12 @@
 package remote_api
 
 import (
+	"log"
+	"net/http"
 	"testing"
+
+	"golang.org/x/net/context"
+	"google.golang.org/appengine/datastore"
 )
 
 func TestAppIDRE(t *testing.T) {
@@ -20,5 +25,19 @@ func TestAppIDRE(t *testing.T) {
 		if g := appIDRE.FindStringSubmatch(v); g == nil || g[1] != appID {
 			t.Errorf("appIDRE.FindStringSubmatch(%s) got %q, want %q", v, g, appID)
 		}
+	}
+}
+
+func ExampleClient() {
+	c, err := NewClient("example.appspot.com", http.DefaultClient)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	ctx := context.Background() // or from a request
+	ctx = c.NewContext(ctx)
+	_, err = datastore.Put(ctx, datastore.NewIncompleteKey(ctx, "Foo", nil), struct{ Bar int }{42})
+	if err != nil {
+		log.Fatal(err)
 	}
 }


### PR DESCRIPTION
Allows for contexts to be created inside of a request instead of
deriving from a single application-scoped context.

Fixes #86

/cc @shantuo @cybrcodr @stephenmw