### PR TITLE
datastore: add omitempty support for time.Time

### DIFF
--- a/datastore/save.go
+++ b/datastore/save.go
@@ -145,6 +145,9 @@ func saveStructProperty(props *[]Property, name string, opts saveOpts, v reflect
 	case *Key:
 		p.Value = x
 	case time.Time:
+		if opts.omitEmpty && x.IsZero() {
+			return nil
+		}
 		p.Value = x
 	case appengine.BlobKey:
 		p.Value = x


### PR DESCRIPTION
There are two advantages of this change:

1. Saves datastore space (and cost).
2. Avoids noise in the datastore viewer in the form of `0001-01-01 00:00:00` timestamps.

It was tough to decide where to put this check. I avoided `func isEmptyValue` since it's copy pasta from `encoding/json` and it would require an additional type assertion that is already being done in `func saveStructProperty`.

Closes #98