### PR TITLE
search: fix language code of Japanese

### DIFF
--- a/search/search_test.go
+++ b/search/search_test.go
@@ -194,7 +194,7 @@ func TestLoadFieldList(t *testing.T) {
 func TestLangFields(t *testing.T) {
 	fl := &FieldList{
 		{Name: "Foo", Value: "I am English", Language: "en"},
-		{Name: "Bar", Value: "私は日本人だ", Language: "jp"},
+		{Name: "Bar", Value: "私は日本人だ", Language: "ja"},
 	}
 	var got FieldList
 	doc, err := saveDoc(fl)


### PR DESCRIPTION
https://cloud.google.com/appengine/docs/standard/go/search/reference#Field
According to the document, Language of Field is "two-letter ISO 639-1 code for the field's language". ISO 639-1 code for Japanese is "ja", not "jp", so I fixed it.
https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes