### PR TITLE
datastore: fix doc typo in datastore/query.go

### DIFF
--- a/datastore/query.go
+++ b/datastore/query.go
@@ -445,7 +445,7 @@ func callNext(c context.Context, res *pb.QueryResult, offset, limit int32) error
 // If q is a ``keys-only'' query, GetAll ignores dst and only returns the keys.
 //
 // The running time and number of API calls made by GetAll scale linearly with
-// with the sum of the query's offset and limit. Unless the result count is
+// the sum of the query's offset and limit. Unless the result count is
 // expected to be small, it is best to specify a limit; otherwise GetAll will
 // continue until it finishes collecting results or the provided context
 // expires.


### PR DESCRIPTION
Fix doc for datastore/query.go.