### PR TITLE
internal: for Flex, use req.Context instead of a context map

### DIFF
--- a/aetest/instance_vm.go
+++ b/aetest/instance_vm.go
@@ -71,7 +71,7 @@ func (i *instance) NewRequest(method, urlStr string, body io.Reader) (*http.Requ
 	}
 
 	// Associate this request.
-	release := internal.RegisterTestRequest(req, i.apiURL, func(ctx context.Context) context.Context {
+	req, release := internal.RegisterTestRequest(req, i.apiURL, func(ctx context.Context) context.Context {
 		ctx = internal.WithAppIDOverride(ctx, "dev~"+i.appID)
 		return ctx
 	})

--- a/appengine.go
+++ b/appengine.go
@@ -63,7 +63,7 @@ func IsDevAppServer() bool {
 // NewContext returns a context for an in-flight HTTP request.
 // This function is cheap.
 func NewContext(req *http.Request) context.Context {
-	return WithContext(context.Background(), req)
+	return internal.ReqContext(req)
 }
 
 // WithContext returns a copy of the parent context

--- a/internal/api.go
+++ b/internal/api.go
@@ -267,13 +267,14 @@ func IncomingHeaders(ctx netcontext.Context) http.Header {
 	return nil
 }
 
+func ReqContext(req *http.Request) netcontext.Context {
+	return req.Context()
+}
+
 func WithContext(parent netcontext.Context, req *http.Request) netcontext.Context {
-	if parent == netcontext.Background() {
-		return req.Context()
-	}
 	return jointContext{
-		base:       req.Context(),
-		valuesOnly: parent,
+		base:       parent,
+		valuesOnly: req.Context(),
 	}
 }
 

--- a/internal/api_classic.go
+++ b/internal/api_classic.go
@@ -59,6 +59,10 @@ func IncomingHeaders(ctx netcontext.Context) http.Header {
 	return nil
 }
 
+func ReqContext(req *http.Request) netcontext.Context {
+	return WithContext(netcontext.Background(), req)
+}
+
 func WithContext(parent netcontext.Context, req *http.Request) netcontext.Context {
 	c := appengine.NewContext(req)
 	return withContext(parent, c)

--- a/internal/api_pre17.go
+++ b/internal/api_pre17.go
@@ -254,6 +254,10 @@ func IncomingHeaders(ctx netcontext.Context) http.Header {
 	return nil
 }
 
+func ReqContext(req *http.Request) netcontext.Context {
+	return WithContext(netcontext.Background(), req)
+}
+
 func WithContext(parent netcontext.Context, req *http.Request) netcontext.Context {
 	ctxs.Lock()
 	c := ctxs.m[req]


### PR DESCRIPTION
api_pre17.go is a copy of the previous api.go, kept for backwards compatibility.