### PR TITLE
aetest: hook to add other yaml in test app directory on vm

### DIFF
--- a/aetest/instance.go
+++ b/aetest/instance.go
@@ -53,3 +53,9 @@ func NewContext() (context.Context, func(), error) {
 // dev_appserver.py is started, each time it is started. If aetest.NewContext
 // is invoked from the goapp test tool, this hook is unnecessary.
 var PrepareDevAppserver func() error
+
+// PrepareOtherYAML is a hook which, if set, will be called after
+// the test app directory is created, each time dev_appserver.py is started.
+// If aetest.NewContext is invoked from the goapp test tool, this hook is no effect.
+// This hook works in aetest.NewContext invoked from the go test tool.
+var PrepareOtherYAML func(appDir string) error

--- a/aetest/instance_vm.go
+++ b/aetest/instance_vm.go
@@ -186,6 +186,11 @@ func (i *instance) startChild() (err error) {
 	if err != nil {
 		return err
 	}
+	if PrepareOtherYAML != nil {
+		if err := PrepareOtherYAML(filepath.Join(i.appDir, "app")); err != nil {
+			return err
+		}
+	}
 
 	appserverArgs := []string{
 		devAppserver,


### PR DESCRIPTION
I think there are many demand to use named taskqueue by aetest. I am also one of them. Current, we cannot test it by aetest package. Unknown queue error raises. There is some implementation of appengine context for test. But, I want to test using official package. Therefore, I send this pull request.
To support on classic, I think needs to write same code to source in official go appengine tool(goroot-1.6/src/appengine or goroot-1.8/src/appengine).