### PR TITLE
Update cloudsql_classic.go

### DIFF
--- a/cloudsql/cloudsql_classic.go
+++ b/cloudsql/cloudsql_classic.go
@@ -9,7 +9,7 @@ package cloudsql
 import (
 	"net"
 
-	"appengine/cloudsql"
+	"google.golang.org/appengine/cloudsql"
 )
 
 func connect(instance string) (net.Conn, error) {


### PR DESCRIPTION
Hello

when I vendorize the latest version of `go-sql-driver/mysql/` using govendor, it still says that there is a missing package "appengine/cloudsql" and it is annoying. it seems came from this file but since there is a build tag `appengine` I don't known if this is some internal package that no one should touch OR maybe my change make sense.

Regards

Tiago Peczenyj