### PR TITLE
Update cloudsql_classic.go

### DIFF
--- a/cloudsql/cloudsql_classic.go
+++ b/cloudsql/cloudsql_classic.go
@@ -8,8 +8,6 @@ package cloudsql
 
 import (
 	"net"
-
-	"appengine/cloudsql"
 )
 
 func connect(instance string) (net.Conn, error) {


### PR DESCRIPTION
the package "appengine/cloudsql" make my govendor crazy, show that package is missing