### PR TITLE
aetest: Add new option to suppress dev_appserver logs

### DIFF
--- a/aetest/instance.go
+++ b/aetest/instance.go
@@ -25,6 +25,9 @@ type Options struct {
 	// StronglyConsistentDatastore is whether the local datastore should be
 	// strongly consistent. This will diverge from production behaviour.
 	StronglyConsistentDatastore bool
+	// SuppressDevAppServerLog is whether the dev_appserver running in tests
+	// should output logs.
+	SuppressDevAppServerLog bool
 	// StartupTimeout is a duration to wait for instance startup.
 	// By default, 15 seconds.
 	StartupTimeout time.Duration

--- a/aetest/instance_vm.go
+++ b/aetest/instance_vm.go
@@ -212,7 +212,9 @@ func (i *instance) startChild() (err error) {
 	if err != nil {
 		return err
 	}
-	stderr = io.TeeReader(stderr, os.Stderr)
+	if !(i.opts != nil && i.opts.SuppressDevAppServerLog) {
+		stderr = io.TeeReader(stderr, os.Stderr)
+	}
 	if err = i.child.Start(); err != nil {
 		return err
 	}


### PR DESCRIPTION
During testing with the `aetest`'s test instance, some logs generated by underlying dev_appserver appear in outputs.
It's little annoying for reading results of tests.
Therefore, I made a new option parameter to suppress dev_appserver's logs.

How is this?