### PR TITLE
datastore: add omitempty support for time.Time - within isEmptyValue() + updated unit tests

### DIFF
--- a/datastore/datastore_test.go
+++ b/datastore/datastore_test.go
@@ -144,20 +144,23 @@ type NoOmit struct {
 	A string
 	B int  `datastore:"Bb"`
 	C bool `datastore:",noindex"`
+	D time.Time
 }
 
 type OmitAll struct {
-	A string `datastore:",omitempty"`
-	B int    `datastore:"Bb,omitempty"`
-	C bool   `datastore:",omitempty,noindex"`
-	F []int  `datastore:",omitempty"`
+	A string    `datastore:",omitempty"`
+	B int       `datastore:"Bb,omitempty"`
+	C bool      `datastore:",omitempty,noindex"`
+	D time.Time `datastore:",omitempty"`
+	F []int     `datastore:",omitempty"`
 }
 
 type Omit struct {
-	A string `datastore:",omitempty"`
-	B int    `datastore:"Bb,omitempty"`
-	C bool   `datastore:",omitempty,noindex"`
-	F []int  `datastore:",omitempty"`
+	A string    `datastore:",omitempty"`
+	B int       `datastore:"Bb,omitempty"`
+	C bool      `datastore:",omitempty,noindex"`
+	D time.Time `datastore:",omitempty"`
+	F []int     `datastore:",omitempty"`
 	S `datastore:",omitempty"`
 }
 
@@ -548,12 +551,14 @@ var testCases = []testCase{
 			A: "a",
 			B: 10,
 			C: true,
+			D: now,
 			F: []int{11},
 		},
 		&PropertyList{
 			Property{Name: "A", Value: "a", NoIndex: false, Multiple: false},
 			Property{Name: "Bb", Value: int64(10), NoIndex: false, Multiple: false},
 			Property{Name: "C", Value: true, NoIndex: true, Multiple: false},
+			Property{Name: "D", Value: now, NoIndex: false, Multiple: false},
 			Property{Name: "F", Value: int64(11), NoIndex: false, Multiple: true},
 			Property{Name: "St", Value: "", NoIndex: false, Multiple: false},
 		},
@@ -566,6 +571,7 @@ var testCases = []testCase{
 			A: "a",
 			B: 10,
 			C: true,
+			D: now,
 			F: []int{11},
 			S: S{St: "string"},
 		},
@@ -573,6 +579,7 @@ var testCases = []testCase{
 			Property{Name: "A", Value: "a", NoIndex: false, Multiple: false},
 			Property{Name: "Bb", Value: int64(10), NoIndex: false, Multiple: false},
 			Property{Name: "C", Value: true, NoIndex: true, Multiple: false},
+			Property{Name: "D", Value: now, NoIndex: false, Multiple: false},
 			Property{Name: "F", Value: int64(11), NoIndex: false, Multiple: true},
 			Property{Name: "St", Value: "string", NoIndex: false, Multiple: false},
 		},
@@ -592,6 +599,7 @@ var testCases = []testCase{
 			Property{Name: "No.A", Value: "", NoIndex: false, Multiple: true},
 			Property{Name: "No.Bb", Value: int64(0), NoIndex: false, Multiple: true},
 			Property{Name: "No.C", Value: false, NoIndex: true, Multiple: true},
+			Property{Name: "No.D", Value: time.Time{}, NoIndex: false, Multiple: true},
 			Property{Name: "Ss.St", Value: "", NoIndex: false, Multiple: false},
 			Property{Name: "St", Value: "", NoIndex: false, Multiple: false}},
 		"",

--- a/datastore/datastore_test.go
+++ b/datastore/datastore_test.go
@@ -144,7 +144,6 @@ type NoOmit struct {
 	A string
 	B int  `datastore:"Bb"`
 	C bool `datastore:",noindex"`
-	D time.Time
 }
 
 type OmitAll struct {
@@ -599,7 +598,6 @@ var testCases = []testCase{
 			Property{Name: "No.A", Value: "", NoIndex: false, Multiple: true},
 			Property{Name: "No.Bb", Value: int64(0), NoIndex: false, Multiple: true},
 			Property{Name: "No.C", Value: false, NoIndex: true, Multiple: true},
-			Property{Name: "No.D", Value: time.Time{}, NoIndex: false, Multiple: true},
 			Property{Name: "Ss.St", Value: "", NoIndex: false, Multiple: false},
 			Property{Name: "St", Value: "", NoIndex: false, Multiple: false}},
 		"",

--- a/datastore/prop_test.go
+++ b/datastore/prop_test.go
@@ -553,7 +553,7 @@ func TestSaveStructOmitEmpty(t *testing.T) {
 	expectedPropNamesForSlices := []string{"NonEmptyValue", "NonEmptyValue", "OmitEmptyWithValue", "OmitEmptyWithValue"}
 
 	testOmitted := func(expectedPropNames []string, src interface{}) {
-		t.Helper()
+		// t.Helper() - this is available from Go version 1.9, but we also support Go versions 1.6, 1.7, 1.8
 		if props, err := SaveStruct(src); err != nil {
 			t.Fatal(err)
 		} else {

--- a/datastore/prop_test.go
+++ b/datastore/prop_test.go
@@ -6,6 +6,7 @@ package datastore
 
 import (
 	"reflect"
+	"sort"
 	"testing"
 	"time"
 
@@ -547,31 +548,31 @@ func TestNilKeyIsStored(t *testing.T) {
 }
 
 func TestSaveStructOmitEmpty(t *testing.T) {
-	expectedPropNames := []string{"EmptyValue", "NonEmptyValue", "OmitEmptyWithValue"}
+	// Expected props names are sorted alphabetically
+	expectedPropNamesForSingles := []string{"EmptyValue", "NonEmptyValue", "OmitEmptyWithValue"}
+	expectedPropNamesForSlices := []string{"NonEmptyValue", "NonEmptyValue", "OmitEmptyWithValue", "OmitEmptyWithValue"}
 
-	assert := func(src interface{}) {
+	testOmitted := func(expectedPropNames []string, src interface{}) {
 		t.Helper()
 		if props, err := SaveStruct(src); err != nil {
 			t.Fatal(err)
-		} else if len(props) != len(expectedPropNames) {
-			t.Errorf("Expected %v properties, got %v", len(expectedPropNames), len(props))
 		} else {
-			expected := make([]string, len(expectedPropNames))
-			copy(expected, expectedPropNames)
-		PROPS:
-			for _, p := range props {
-				for i, name := range expected {
-					if p.Name == name {
-						expected = append(expected[:i], expected[i+1:]...)
-						continue PROPS
-					}
-				}
-				t.Errorf("Unexpected property: %v", p.Name)
+			// Collect names for reporting if diffs from expected
+			actualPropNames := make([]string, len(props))
+			for i := range props {
+				actualPropNames[i] = props[i].Name
+			}
+			// and sort actuals for comparing with already sorted expected names
+			sort.Slice(actualPropNames, func(i, j int) bool {
+				return actualPropNames[i] < actualPropNames[j]
+			})
+			if !reflect.DeepEqual(actualPropNames, expectedPropNames) {
+				t.Errorf("Expected this properties: %v, got: %v", expectedPropNames, actualPropNames)
 			}
 		}
 	}
 
-	assert(&struct {
+	testOmitted(expectedPropNamesForSingles, &struct {
 		EmptyValue         int
 		NonEmptyValue      int
 		OmitEmptyNoValue   int `datastore:",omitempty"`
@@ -581,18 +582,37 @@ func TestSaveStructOmitEmpty(t *testing.T) {
 		OmitEmptyWithValue: 2,
 	})
 
-	// TODO: The uint is unsuported property type but is checked in func isEmptyValue() - probably should be removed from there
-	// assert(&struct {
-	// 	EmptyValue         uint
-	// 	NonEmptyValue      uint
-	// 	OmitEmptyNoValue   uint `datastore:",omitempty"`
-	// 	OmitEmptyWithValue uint `datastore:",omitempty"`
-	// }{
-	// 	NonEmptyValue:      1,
-	// 	OmitEmptyWithValue: 2,
-	// })
+	testOmitted(expectedPropNamesForSlices, &struct {
+		EmptyValue         []int
+		NonEmptyValue      []int
+		OmitEmptyNoValue   []int `datastore:",omitempty"`
+		OmitEmptyWithValue []int `datastore:",omitempty"`
+	}{
+		NonEmptyValue:      []int{1, 2},
+		OmitEmptyWithValue: []int{3, 4},
+	})
 
-	assert(&struct {
+	testOmitted(expectedPropNamesForSingles, &struct {
+		EmptyValue         bool
+		NonEmptyValue      bool
+		OmitEmptyNoValue   bool `datastore:",omitempty"`
+		OmitEmptyWithValue bool `datastore:",omitempty"`
+	}{
+		NonEmptyValue:      true,
+		OmitEmptyWithValue: true,
+	})
+
+	testOmitted(expectedPropNamesForSlices, &struct {
+		EmptyValue         []bool
+		NonEmptyValue      []bool
+		OmitEmptyNoValue   []bool `datastore:",omitempty"`
+		OmitEmptyWithValue []bool `datastore:",omitempty"`
+	}{
+		NonEmptyValue:      []bool{true, true},
+		OmitEmptyWithValue: []bool{true, true},
+	})
+
+	testOmitted(expectedPropNamesForSingles, &struct {
 		EmptyValue         string
 		NonEmptyValue      string
 		OmitEmptyNoValue   string `datastore:",omitempty"`
@@ -602,7 +622,17 @@ func TestSaveStructOmitEmpty(t *testing.T) {
 		OmitEmptyWithValue: "s",
 	})
 
-	assert(&struct {
+	testOmitted(expectedPropNamesForSlices, &struct {
+		EmptyValue         []string
+		NonEmptyValue      []string
+		OmitEmptyNoValue   []string `datastore:",omitempty"`
+		OmitEmptyWithValue []string `datastore:",omitempty"`
+	}{
+		NonEmptyValue:      []string{"s1", "s2"},
+		OmitEmptyWithValue: []string{"s3", "s4"},
+	})
+
+	testOmitted(expectedPropNamesForSingles, &struct {
 		EmptyValue         float32
 		NonEmptyValue      float32
 		OmitEmptyNoValue   float32 `datastore:",omitempty"`
@@ -612,7 +642,17 @@ func TestSaveStructOmitEmpty(t *testing.T) {
 		OmitEmptyWithValue: 1.2,
 	})
 
-	assert(&struct {
+	testOmitted(expectedPropNamesForSlices, &struct {
+		EmptyValue         []float32
+		NonEmptyValue      []float32
+		OmitEmptyNoValue   []float32 `datastore:",omitempty"`
+		OmitEmptyWithValue []float32 `datastore:",omitempty"`
+	}{
+		NonEmptyValue:      []float32{1.1, 2.2},
+		OmitEmptyWithValue: []float32{3.3, 4.4},
+	})
+
+	testOmitted(expectedPropNamesForSingles, &struct {
 		EmptyValue         time.Time
 		NonEmptyValue      time.Time
 		OmitEmptyNoValue   time.Time `datastore:",omitempty"`
@@ -620,5 +660,15 @@ func TestSaveStructOmitEmpty(t *testing.T) {
 	}{
 		NonEmptyValue:      now,
 		OmitEmptyWithValue: now,
+	})
+
+	testOmitted(expectedPropNamesForSlices, &struct {
+		EmptyValue         []time.Time
+		NonEmptyValue      []time.Time
+		OmitEmptyNoValue   []time.Time `datastore:",omitempty"`
+		OmitEmptyWithValue []time.Time `datastore:",omitempty"`
+	}{
+		NonEmptyValue:      []time.Time{now, now},
+		OmitEmptyWithValue: []time.Time{now, now},
 	})
 }

--- a/datastore/prop_test.go
+++ b/datastore/prop_test.go
@@ -562,7 +562,7 @@ func TestSaveStructOmitEmpty(t *testing.T) {
 			for i := range props {
 				actualPropNames[i] = props[i].Name
 			}
-			// and sort actuals for comparing with already sorted expected names
+			// Sort actuals for comparing with already sorted expected names
 			sort.Sort(sort.StringSlice(actualPropNames))
 			if !reflect.DeepEqual(actualPropNames, expectedPropNames) {
 				t.Errorf("Expected this properties: %v, got: %v", expectedPropNames, actualPropNames)

--- a/datastore/prop_test.go
+++ b/datastore/prop_test.go
@@ -557,15 +557,13 @@ func TestSaveStructOmitEmpty(t *testing.T) {
 		if props, err := SaveStruct(src); err != nil {
 			t.Fatal(err)
 		} else {
-			// Collect names for reporting if diffs from expected
+			// Collect names for reporting if diffs from expected and for easier sorting
 			actualPropNames := make([]string, len(props))
 			for i := range props {
 				actualPropNames[i] = props[i].Name
 			}
 			// and sort actuals for comparing with already sorted expected names
-			sort.Slice(actualPropNames, func(i, j int) bool {
-				return actualPropNames[i] < actualPropNames[j]
-			})
+			sort.Sort(sort.StringSlice(actualPropNames))
 			if !reflect.DeepEqual(actualPropNames, expectedPropNames) {
 				t.Errorf("Expected this properties: %v, got: %v", expectedPropNames, actualPropNames)
 			}

--- a/datastore/save.go
+++ b/datastore/save.go
@@ -322,6 +322,11 @@ func isEmptyValue(v reflect.Value) bool {
 		return v.Float() == 0
 	case reflect.Interface, reflect.Ptr:
 		return v.IsNil()
+	case reflect.Struct:
+		switch x := v.Interface().(type) {
+		case time.Time:
+			return x.IsZero()
+		}
 	}
 	return false
 }

--- a/datastore/save.go
+++ b/datastore/save.go
@@ -306,17 +306,18 @@ func propertiesToProto(defaultAppID string, key *Key, props []Property) (*pb.Ent
 	return e, nil
 }
 
-// isEmptyValue is taken from the encoding/json package in the
-// standard library.
+// isEmptyValue is taken from the encoding/json package in the standard library.
 func isEmptyValue(v reflect.Value) bool {
 	switch v.Kind() {
 	case reflect.Array, reflect.Map, reflect.Slice, reflect.String:
+		// TODO(perfomance): Only relect.String needed, other property types are not supported (copy/paste from json package)
 		return v.Len() == 0
 	case reflect.Bool:
 		return !v.Bool()
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 		return v.Int() == 0
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		// TODO(perfomance): Uint* are unsuported property types - should be removed (copy/paste from json package)
 		return v.Uint() == 0
 	case reflect.Float32, reflect.Float64:
 		return v.Float() == 0

--- a/datastore/save.go
+++ b/datastore/save.go
@@ -310,14 +310,14 @@ func propertiesToProto(defaultAppID string, key *Key, props []Property) (*pb.Ent
 func isEmptyValue(v reflect.Value) bool {
 	switch v.Kind() {
 	case reflect.Array, reflect.Map, reflect.Slice, reflect.String:
-		// TODO(perfomance): Only relect.String needed, other property types are not supported (copy/paste from json package)
+		// TODO(perfomance): Only reflect.String needed, other property types are not supported (copy/paste from json package)
 		return v.Len() == 0
 	case reflect.Bool:
 		return !v.Bool()
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 		return v.Int() == 0
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
-		// TODO(perfomance): Uint* are unsuported property types - should be removed (copy/paste from json package)
+		// TODO(perfomance): Uint* are unsupported property types - should be removed (copy/paste from json package)
 		return v.Uint() == 0
 	case reflect.Float32, reflect.Float64:
 		return v.Float() == 0


### PR DESCRIPTION
There are 4 advantages of this change:

1. Saves datastore space (_and cost_).
2. Should slightly decrease write time & write ops (_and costs_) for entities with empty indexed time properties.
3. Avoids noise in the datastore viewer in the form of 0001-01-01 00:00:00 timestamps.
4. Eliminates need to implement `PropertyLoadSaver` to achieve the same.

This change modifies `func isEmptyValue()`. This requires additional type assertion but only for `time.Time` fields with `omitempty` label. Ideally `isEmptyValue()` should be removed completely as it is called just in 1 place inside  `func saveStructProperty()` and it can be a bit optimized. But that would be a too big change and pros are not too big so I believe this can/should be done as a separate PR if desired.

Closes https://github.com/golang/appengine/issues/98

Alternative to PR https://github.com/golang/appengine/pull/101 that seems to get abandoned and has no unit tests.