### PR TITLE
travis: test Go 1.10 and use newer SDK

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ go_import_path: google.golang.org/appengine
 install:
   - go get -u -v $(go list -f '{{join .Imports "\n"}}{{"\n"}}{{join .TestImports "\n"}}' ./... | sort | uniq | grep -v appengine)
   - mkdir /tmp/sdk
-  - curl -o /tmp/sdk.zip "https://storage.googleapis.com/appengine-sdks/featured/go_appengine_sdk_linux_amd64-1.9.64.zip"
+  - curl -o /tmp/sdk.zip "https://storage.googleapis.com/appengine-sdks/featured/go_appengine_sdk_linux_amd64-1.9.67.zip"
   - unzip -q /tmp/sdk.zip -d /tmp/sdk
   - export PATH="$PATH:/tmp/sdk/go_appengine"
   - export APPENGINE_DEV_APPSERVER=/tmp/sdk/go_appengine/dev_appserver.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ go:
   - 1.7.x
   - 1.8.x
   - 1.9.x
+  - 1.10.x
 
 go_import_path: google.golang.org/appengine
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ go_import_path: google.golang.org/appengine
 install:
   - go get -u -v $(go list -f '{{join .Imports "\n"}}{{"\n"}}{{join .TestImports "\n"}}' ./... | sort | uniq | grep -v appengine)
   - mkdir /tmp/sdk
-  - curl -o /tmp/sdk.zip "https://storage.googleapis.com/appengine-sdks/featured/go_appengine_sdk_linux_amd64-1.9.40.zip"
+  - curl -o /tmp/sdk.zip "https://storage.googleapis.com/appengine-sdks/featured/go_appengine_sdk_linux_amd64-1.9.64.zip"
   - unzip -q /tmp/sdk.zip -d /tmp/sdk
   - export PATH="$PATH:/tmp/sdk/go_appengine"
   - export APPENGINE_DEV_APPSERVER=/tmp/sdk/go_appengine/dev_appserver.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ go:
   - 1.8.x
   - 1.9.x
   - 1.10.x
+  - 1.11.x
 
 go_import_path: google.golang.org/appengine
 


### PR DESCRIPTION
* Include Go 1.10 in the list of Go versions to test
* Use a newer SDK zip