### PR TITLE
datastore: fix behavior when ErrConcurrentTransaction occured

### DIFF
--- a/internal/transaction.go
+++ b/internal/transaction.go
@@ -72,6 +72,8 @@ func RunTransactionOnce(c netcontext.Context, f func(netcontext.Context) error, 
 	}
 	if readOnly {
 		req.Mode = pb.BeginTransactionRequest_READ_ONLY.Enum()
+	} else {
+		req.Mode = pb.BeginTransactionRequest_READ_WRITE.Enum()
 	}
 	if err := Call(c, "datastore_v3", "BeginTransaction", req, &t.transaction); err != nil {
 		return nil, err


### PR DESCRIPTION
#108 made ReadOnly property and previousTransaction argument.
`BeginTransactionRequest.Mode`'s default value is `BeginTransactionRequest_UNKNOWN`.
But `req.PreviousTransaction` required `BeginTransactionRequest_READ_WRITE`.

This test passed before #108 . but after #108 is not.
We get `API error 1 (datastore_v3: BAD_REQUEST): previous_transaction can only be set in READ_WRITE mode` now.

```
// ErrConcurrentTransaction will be occur
err = datastore.RunInTransaction(ctx, func(txCtx1 netcontext.Context) error {
	err := datastore.Get(txCtx1, key, &Data{})
	if err != nil {
		return err
	}

	err = datastore.RunInTransaction(ctx, func(txCtx2 netcontext.Context) error {
		err := datastore.Get(txCtx2, key, &Data{})
		if err != nil {
			return err
		}

		_, err = datastore.Put(txCtx2, key, &Data{Str: "#2"})
		return err
	}, &datastore.TransactionOptions{XG: true})
	if err != nil {
		return err
	}

	_, err = datastore.Put(txCtx1, key, &Data{Str: "#1"})
	return err
}, &datastore.TransactionOptions{XG: true})
if err != datastore.ErrConcurrentTransaction {
	t.Fatal(err)
}
```
