### PR TITLE
Ensure at least one log flush happens before request ends

### DIFF
--- a/internal/api_test.go
+++ b/internal/api_test.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -250,6 +251,53 @@ func TestDelayedLogFlushing(t *testing.T) {
 	f, c, cleanup := setup()
 	defer cleanup()
 
+	http.HandleFunc("/slow_log", func(w http.ResponseWriter, r *http.Request) {
+		logC := WithContext(netcontext.Background(), r)
+		fromContext(logC).apiURL = c.apiURL // Otherwise it will try to use the default URL.
+		Logf(logC, 1, "It's a lovely day.")
+		w.WriteHeader(200)
+		time.Sleep(1200 * time.Millisecond)
+		w.Write(make([]byte, 100<<10)) // write 100 KB to force HTTP flush
+	})
+
+	r := &http.Request{
+		Method: "GET",
+		URL: &url.URL{
+			Scheme: "http",
+			Path:   "/slow_log",
+		},
+		Header: c.req.Header,
+		Body:   ioutil.NopCloser(bytes.NewReader(nil)),
+	}
+	w := httptest.NewRecorder()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		handleHTTP(w, r)
+	}()
+	// Check that the log flush eventually comes in.
+	time.Sleep(1200 * time.Millisecond)
+	if f := atomic.LoadInt32(&f.LogFlushes); f != 1 {
+		t.Errorf("After 1.5s: f.LogFlushes = %d, want 1", f)
+	}
+
+	wg.Wait()
+	const hdr = "X-AppEngine-Log-Flush-Count"
+	if got, want := w.HeaderMap.Get(hdr), "1"; got != want {
+		t.Errorf("%s header = %q, want %q", hdr, got, want)
+	}
+	if got, want := atomic.LoadInt32(&f.LogFlushes), int32(2); got != want {
+		t.Errorf("After HTTP response: f.LogFlushes = %d, want %d", got, want)
+	}
+
+}
+
+func TestLogFlushing(t *testing.T) {
+	f, c, cleanup := setup()
+	defer cleanup()
+
 	http.HandleFunc("/quick_log", func(w http.ResponseWriter, r *http.Request) {
 		logC := WithContext(netcontext.Background(), r)
 		fromContext(logC).apiURL = c.apiURL // Otherwise it will try to use the default URL.
@@ -269,24 +317,13 @@ func TestDelayedLogFlushing(t *testing.T) {
 	}
 	w := httptest.NewRecorder()
 
-	// Check that log flushing does not hold up the HTTP response.
-	start := time.Now()
 	handleHTTP(w, r)
-	if d := time.Since(start); d > 10*time.Millisecond {
-		t.Errorf("handleHTTP took %v, want under 10ms", d)
-	}
 	const hdr = "X-AppEngine-Log-Flush-Count"
-	if h := w.HeaderMap.Get(hdr); h != "1" {
-		t.Errorf("%s header = %q, want %q", hdr, h, "1")
+	if got, want := w.HeaderMap.Get(hdr), "1"; got != want {
+		t.Errorf("%s header = %q, want %q", hdr, got, want)
 	}
-	if f := atomic.LoadInt32(&f.LogFlushes); f != 0 {
-		t.Errorf("After HTTP response: f.LogFlushes = %d, want 0", f)
-	}
-
-	// Check that the log flush eventually comes in.
-	time.Sleep(100 * time.Millisecond)
-	if f := atomic.LoadInt32(&f.LogFlushes); f != 1 {
-		t.Errorf("After 100ms: f.LogFlushes = %d, want 1", f)
+	if got, want := atomic.LoadInt32(&f.LogFlushes), int32(1); got != want {
+		t.Errorf("After HTTP response: f.LogFlushes = %d, want %d", got, want)
 	}
 }
 

--- a/internal/api_test.go
+++ b/internal/api_test.go
@@ -280,7 +280,7 @@ func TestDelayedLogFlushing(t *testing.T) {
 	// Check that the log flush eventually comes in.
 	time.Sleep(1200 * time.Millisecond)
 	if f := atomic.LoadInt32(&f.LogFlushes); f != 1 {
-		t.Errorf("After 1.5s: f.LogFlushes = %d, want 1", f)
+		t.Errorf("After 1.2s: f.LogFlushes = %d, want 1", f)
 	}
 
 	wg.Wait()


### PR DESCRIPTION
Fixes #163

The Go 1.11 runtime on GAE Standard is closing the connection before the logs are flushed, which invalidates the security ticket needed to send logs to stackdriver. This can be mitigated by forcing a log flush to happen before the request closes.