### PR TITLE
Add functions that check which environment the app is running in

### DIFF
--- a/appengine.go
+++ b/appengine.go
@@ -60,6 +60,24 @@ func IsDevAppServer() bool {
 	return internal.IsDevAppServer()
 }
 
+// IsStandard reports whether the App Engine app is running in the standard
+// environment. This includes both the first generation runtimes (<= Go 1.9)
+// and the second generation runtimes (>= Go 1.11).
+func IsStandard() bool {
+	return internal.IsStandard()
+}
+
+// IsFlex reports whether the App Engine app is running in the flexible environment.
+func IsFlex() bool {
+	return internal.IsFlex()
+}
+
+// IsAppEngine reports whether the App Engine app is running on App Engine, in either
+// the standard or flexible environment.
+func IsAppEngine() bool {
+	return internal.IsAppEngine()
+}
+
 // NewContext returns a context for an in-flight HTTP request.
 // This function is cheap.
 func NewContext(req *http.Request) context.Context {

--- a/internal/identity.go
+++ b/internal/identity.go
@@ -4,11 +4,46 @@
 
 package internal
 
-import netcontext "golang.org/x/net/context"
+import (
+	"os"
 
-// These functions are implementations of the wrapper functions
-// in ../appengine/identity.go. See that file for commentary.
+	netcontext "golang.org/x/net/context"
+)
 
+var (
+	// This is set to true in identity_classic.go, which is behind the appengine build tag.
+	// The appengine build tag is set for the first generation runtimes (<= Go 1.9) but not
+	// the second generation runtimes (>= Go 1.11), so this indicates whether we're on a
+	// first-gen runtime. See IsStandard below for the second-gen check.
+	appengineStandard bool
+
+	// This is set to true in identity_flex.go, which is behind the appenginevm build tag.
+	appengineFlex bool
+)
+
+// AppID is the implementation of the wrapper function of the same name in
+// ../identity.go. See that file for commentary.
 func AppID(c netcontext.Context) string {
 	return appID(FullyQualifiedAppID(c))
+}
+
+// IsStandard is the implementation of the wrapper function of the same name in
+// ../appengine.go. See that file for commentary.
+func IsStandard() bool {
+	// appengineStandard will be true for first-gen runtimes (<= Go 1.9) but not
+	// second-gen (>= Go 1.11). Second-gen runtimes set $GAE_ENV so we use that
+	// to check if we're on a second-gen runtime.
+	return appengineStandard || os.Getenv("GAE_ENV") == "standard"
+}
+
+// IsFlex is the implementation of the wrapper function of the same name in
+// ../appengine.go. See that file for commentary.
+func IsFlex() bool {
+	return appengineFlex
+}
+
+// IsAppEngine is the implementation of the wrapper function of the same name in
+// ../appengine.go. See that file for commentary.
+func IsAppEngine() bool {
+	return IsStandard() || IsFlex()
 }

--- a/internal/identity_classic.go
+++ b/internal/identity_classic.go
@@ -12,6 +12,10 @@ import (
 	netcontext "golang.org/x/net/context"
 )
 
+func init() {
+	appengineStandard = true
+}
+
 func DefaultVersionHostname(ctx netcontext.Context) string {
 	c := fromContext(ctx)
 	if c == nil {

--- a/internal/identity_flex.go
+++ b/internal/identity_flex.go
@@ -1,0 +1,11 @@
+// Copyright 2018 Google LLC. All rights reserved.
+// Use of this source code is governed by the Apache 2.0
+// license that can be found in the LICENSE file.
+
+// +build appenginevm
+
+package internal
+
+func init() {
+	appengineFlex = true
+}


### PR DESCRIPTION
This is motivated by the fact that second-generation runtimes
(>= Go 1.11) do not set the appengine build tag, so the build tag alone
is not sufficient to determine whether an app is running in the standard
environment. We can check for a second-gen runtime with $GAE_ENV.
The new functions centralize this logic so other packages don't have to
worry about the build tags and env vars.

Added:
- IsStandard reports whether the App Engine app is running in the
  standard environment. This includes both the first generation
  runtimes (<= Go 1.9) and the second generation runtimes (>= Go 1.11).
- IsFlex reports whether the App Engine app is running in the flexible
  environment.
- IsAppEngine reports whether the App Engine app is running on App
  Engine, in either the standard or flexible environment.

Test: Deployed an app to go1.8 std, go1.9 std, go111 std, and flex. The app
      prints out the return val of each of the new functions. Verified
      correctness.