### PR TITLE
log: don't mirror log to stderr on 2nd gen

### DIFF
--- a/appengine.go
+++ b/appengine.go
@@ -78,6 +78,12 @@ func IsAppEngine() bool {
 	return internal.IsAppEngine()
 }
 
+// IsSecondGen reports whether the App Engine app is running on the second generation
+// runtimes (>= Go 1.11).
+func IsSecondGen() bool {
+	return internal.IsSecondGen()
+}
+
 // NewContext returns a context for an in-flight HTTP request.
 // This function is cheap.
 func NewContext(req *http.Request) context.Context {

--- a/internal/api.go
+++ b/internal/api.go
@@ -579,7 +579,9 @@ func logf(c *context, level int64, format string, args ...interface{}) {
 		Level:         &level,
 		Message:       &s,
 	})
-	log.Print(logLevelName[level] + ": " + s)
+	if !IsSecondGen() {
+		log.Print(logLevelName[level] + ": " + s)
+	}
 }
 
 // flushLog attempts to flush any pending logs to the appserver.

--- a/internal/api.go
+++ b/internal/api.go
@@ -579,6 +579,7 @@ func logf(c *context, level int64, format string, args ...interface{}) {
 		Level:         &level,
 		Message:       &s,
 	})
+	// Only duplicate log to stderr if not running on App Engine second generation
 	if !IsSecondGen() {
 		log.Print(logLevelName[level] + ": " + s)
 	}

--- a/internal/identity.go
+++ b/internal/identity.go
@@ -31,9 +31,15 @@ func AppID(c netcontext.Context) string {
 // ../appengine.go. See that file for commentary.
 func IsStandard() bool {
 	// appengineStandard will be true for first-gen runtimes (<= Go 1.9) but not
-	// second-gen (>= Go 1.11). Second-gen runtimes set $GAE_ENV so we use that
-	// to check if we're on a second-gen runtime.
-	return appengineStandard || os.Getenv("GAE_ENV") == "standard"
+	// second-gen (>= Go 1.11).
+	return appengineStandard || IsSecondGen()
+}
+
+// IsStandard is the implementation of the wrapper function of the same name in
+// ../appengine.go. See that file for commentary.
+func IsSecondGen() bool {
+	// Second-gen runtimes set $GAE_ENV so we use that to check if we're on a second-gen runtime.
+	return os.Getenv("GAE_ENV") == "standard"
 }
 
 // IsFlex is the implementation of the wrapper function of the same name in


### PR DESCRIPTION
`google.golang.org/appengine/log` mirror every log to stderr.
It is recorded as per-line entries.

I think it is too noisy and useless in second generation runtimes.
This PR switches the behavior depending on whether or not the app is running in the second generation runtimes because the behavior should be saved for `remote_api` users who are using another environments.

refs https://github.com/golang/appengine/issues/176#issuecomment-440568565