### PR TITLE
internal: Respect X-Appengine-Dev-Request-Id header

### DIFF
--- a/internal/api.go
+++ b/internal/api.go
@@ -44,6 +44,7 @@ var (
 	curNamespaceHeader = http.CanonicalHeaderKey("X-AppEngine-Current-Namespace")
 	userIPHeader       = http.CanonicalHeaderKey("X-AppEngine-User-IP")
 	remoteAddrHeader   = http.CanonicalHeaderKey("X-AppEngine-Remote-Addr")
+	devRequestIdHeader = http.CanonicalHeaderKey("X-Appengine-Dev-Request-Id")
 
 	// Outgoing headers.
 	apiEndpointHeader      = http.CanonicalHeaderKey("X-Google-RPC-Service-Endpoint")
@@ -494,7 +495,7 @@ func Call(ctx netcontext.Context, service, method string, in, out proto.Message)
 	if ticket == "" {
 		ticket = DefaultTicket()
 	}
-	if dri := c.req.Header.Get("X-Appengine-Dev-Request-Id"); IsDevAppServer() && dri != "" {
+	if dri := c.req.Header.Get(devRequestIdHeader); IsDevAppServer() && dri != "" {
 		ticket = dri
 	}
 	req := &remotepb.Request{

--- a/internal/api.go
+++ b/internal/api.go
@@ -494,6 +494,9 @@ func Call(ctx netcontext.Context, service, method string, in, out proto.Message)
 	if ticket == "" {
 		ticket = DefaultTicket()
 	}
+	if dri := c.req.Header.Get("X-Appengine-Dev-Request-Id"); IsDevAppServer() && dri != "" {
+		ticket = dri
+	}
 	req := &remotepb.Request{
 		ServiceName: &service,
 		Method:      &method,


### PR DESCRIPTION
This adds support for RunInBackground by ensuring that the request ID is correctly associated with the request. Does not fix the issue in prod for `runtime: go111`, which is a separate internal change landing soon.