### PR TITLE
Simplify the capabilities API to remove unnecessary RPC calls

### DIFF
--- a/capability/capability.go
+++ b/capability/capability.go
@@ -43,10 +43,5 @@ func Enabled(ctx context.Context, api, capability string) bool {
 		log.Warningf(ctx, "capability.Enabled: RPC failed: %v", err)
 		return false
 	}
-	switch *res.SummaryStatus {
-	case pb.IsEnabledResponse_ENABLED:
-		return true
-	default:
-		return false
-	}
+	return *res.SummaryStatus == pb.IsEnabledResponse_ENABLED
 }

--- a/capability/capability.go
+++ b/capability/capability.go
@@ -34,18 +34,17 @@ func Enabled(ctx context.Context, api, capability string) bool {
 		Capability: []string{capability},
 	}
 	res := &pb.IsEnabledResponse{}
-	if err := internal.Call(ctx, "capability_service", "IsEnabled", req, res); err != nil {
-		log.Warningf(ctx, "capability.Enabled: RPC failed: %v", err)
-		return false
-	}
+        if api == "datastore_v3" && capability == "write" {
+                if err := internal.Call(ctx, "capability_service", "IsEnabled", req, res); err != nil {
+                        log.Warningf(ctx, "capability.Enabled: RPC failed: %v", err)
+                        return false
+                }
+        } else {
+                return true
+        }
 	switch *res.SummaryStatus {
 	case pb.IsEnabledResponse_ENABLED,
-		pb.IsEnabledResponse_SCHEDULED_FUTURE,
-		pb.IsEnabledResponse_SCHEDULED_NOW:
 		return true
-	case pb.IsEnabledResponse_UNKNOWN:
-		log.Errorf(ctx, "capability.Enabled: unknown API capability %s/%s", api, capability)
-		return false
 	default:
 		return false
 	}

--- a/capability/capability.go
+++ b/capability/capability.go
@@ -34,16 +34,16 @@ func Enabled(ctx context.Context, api, capability string) bool {
 		Capability: []string{capability},
 	}
 	res := &pb.IsEnabledResponse{}
-        if api == "datastore_v3" && capability == "write" {
-                if err := internal.Call(ctx, "capability_service", "IsEnabled", req, res); err != nil {
-                        log.Warningf(ctx, "capability.Enabled: RPC failed: %v", err)
-                        return false
-                }
-        } else {
-                return true
-        }
+	if api == "datastore_v3" && capability == "write" {
+		if err := internal.Call(ctx, "capability_service", "IsEnabled", req, res); err != nil {
+			log.Warningf(ctx, "capability.Enabled: RPC failed: %v", err)
+			return false
+		}
+	} else {
+		return true
+	}
 	switch *res.SummaryStatus {
-	case pb.IsEnabledResponse_ENABLED,
+	case pb.IsEnabledResponse_ENABLED:
 		return true
 	default:
 		return false


### PR DESCRIPTION
The capabilities API was deprecated to only return status for "datastore_v3" and "write", and return ENABLED for everything else. This removes unnecessary RPC calls from the client-side.