### PR TITLE
aetest: Redirect stderr to be visible to the user

### DIFF
--- a/aetest/instance_vm.go
+++ b/aetest/instance_vm.go
@@ -215,9 +215,7 @@ func (i *instance) startChild() (err error) {
 	if err != nil {
 		return err
 	}
-	if !(i.opts != nil && i.opts.SuppressDevAppServerLog) {
-		stderr = io.TeeReader(stderr, os.Stderr)
-	}
+
 	if err = i.child.Start(); err != nil {
 		return err
 	}
@@ -227,6 +225,10 @@ func (i *instance) startChild() (err error) {
 	go func() {
 		s := bufio.NewScanner(stderr)
 		for s.Scan() {
+			// Pass stderr along as we go so the user can see it.
+			if !(i.opts != nil && i.opts.SuppressDevAppServerLog) {
+				fmt.Fprintln(os.Stderr, s.Text())
+			}
 			if match := apiServerAddrRE.FindStringSubmatch(s.Text()); match != nil {
 				u, err := url.Parse(match[1])
 				if err != nil {
@@ -239,6 +241,10 @@ func (i *instance) startChild() (err error) {
 				i.adminURL = match[1]
 			}
 			if i.adminURL != "" && i.apiURL != nil {
+				// Pass along stderr to the user after we're done with it.
+				if !(i.opts != nil && i.opts.SuppressDevAppServerLog) {
+					go io.Copy(os.Stderr, stderr)
+				}
 				break
 			}
 		}


### PR DESCRIPTION
Previously, all stderr after the admin/API server lines was lost as the
StderrPipe continued to consume it without redirecting once the scanner
went out of scope. It also had the side effect of hanging a program in
which the devserver emitted too much data to stderr, since the pipe
would block once it reached cap.

This replaces the TeeReader (which would go out of scope before stderr
was done) by printing the output while processing and copying it once
processing finishes.