### PR TITLE
internal: Increase limitDial timeout from 500ms to 10s

### DIFF
--- a/internal/net.go
+++ b/internal/net.go
@@ -32,7 +32,7 @@ func limitDial(network, addr string) (net.Conn, error) {
 
 	// Dial with a timeout in case the API host is MIA.
 	// The connection should normally be very fast.
-	conn, err := net.DialTimeout(network, addr, 500*time.Millisecond)
+	conn, err := net.DialTimeout(network, addr, 10*time.Second)
 	if err != nil {
 		limitRelease()
 		return nil, err


### PR DESCRIPTION
Increase `internal.limitDial`'s timeout from 500ms to 10s, to account for differences in the go111 legacy API endpoint.