### PR TITLE
delay: fix stable func name to strip gopath prefix

### DIFF
--- a/delay/delay.go
+++ b/delay/delay.go
@@ -118,14 +118,14 @@ var modVersionPat = regexp.MustCompile("@v[^/]+")
 // For calls from package main: strip all leading path entries, leaving just the filename.
 // For calls from anywhere else, strip $GOPATH/src, leaving just the package path and file path.
 func fileKey(file string) (string, error) {
-	if !internal.IsSecondGen() || internal.MainPath == "" {
+	if !internal.IsSecondGen() {
 		return file, nil
 	}
 	// If the caller is in the same Dir as mainPath, then strip everything but the file name.
 	if filepath.Dir(file) == internal.MainPath {
 		return filepath.Base(file), nil
 	}
-	// If the path contains "_gopath/src/", which is what the builder uses for
+	// If the path contains "gopath/src/", which is what the builder uses for
 	// apps which don't use go modules, strip everything up to and including src.
 	// Or, if the path starts with /tmp/staging, then we're importing a package
 	// from the app's module (and we must be using go modules), and we have a
@@ -133,7 +133,7 @@ func fileKey(file string) (string, error) {
 	// including the first /srv/.
 	// And be sure to look at the GOPATH, for local development.
 	s := string(filepath.Separator)
-	for _, s := range []string{filepath.Join("_gopath", "src") + s, s + "srv" + s, filepath.Join(build.Default.GOPATH, "src") + s} {
+	for _, s := range []string{filepath.Join("gopath", "src") + s, s + "srv" + s, filepath.Join(build.Default.GOPATH, "src") + s} {
 		if idx := strings.Index(file, s); idx > 0 {
 			return file[idx+len(s):], nil
 		}

--- a/delay/delay_test.go
+++ b/delay/delay_test.go
@@ -466,7 +466,7 @@ func TestStandardContext(t *testing.T) {
 }
 
 func TestFileKey(t *testing.T) {
-	os.Setenv("GAE_ENV", "standard")
+	const firstGenTest = 0
 	tests := []struct {
 		mainPath string
 		file     string
@@ -499,6 +499,16 @@ func TestFileKey(t *testing.T) {
 			filepath.FromSlash("/tmp/staging3234/srv/_gopath/src/example.com/bar/main.go"),
 			filepath.FromSlash("example.com/bar/main.go"),
 		},
+		{
+			filepath.FromSlash("/tmp/staging3234/srv/gopath/src/example.com/foo"),
+			filepath.FromSlash("/tmp/staging3234/srv/gopath/src/example.com/bar/main.go"),
+			filepath.FromSlash("example.com/bar/main.go"),
+		},
+		{
+			filepath.FromSlash(""),
+			filepath.FromSlash("/tmp/staging3234/srv/gopath/src/example.com/bar/main.go"),
+			filepath.FromSlash("example.com/bar/main.go"),
+		},
 		// go mod, same package
 		{
 			filepath.FromSlash("/tmp/staging3234/srv"),
@@ -520,6 +530,11 @@ func TestFileKey(t *testing.T) {
 			filepath.FromSlash("/tmp/staging3234/srv/bar/main.go"),
 			filepath.FromSlash("bar/main.go"),
 		},
+		{
+			filepath.FromSlash(""),
+			filepath.FromSlash("/tmp/staging3234/srv/bar/main.go"),
+			filepath.FromSlash("bar/main.go"),
+		},
 		// go mod, other package
 		{
 			filepath.FromSlash("/tmp/staging3234/srv"),
@@ -528,6 +543,9 @@ func TestFileKey(t *testing.T) {
 		},
 	}
 	for i, tc := range tests {
+		if i > firstGenTest {
+			os.Setenv("GAE_ENV", "standard")
+		}
 		internal.MainPath = tc.mainPath
 		got, err := fileKey(tc.file)
 		if err != nil {


### PR DESCRIPTION
The path for the files does not contain an underscore anymore, removing it works with the current and the old behavior.
Also if the delay function is defined globally, the internal.MainPath is not available yet. I removed the ` internal.MainPath == ""` check because it was only there for the test and refactored the test a little bit to make it work. 