### PR TITLE
aetest: appYAMLTemplate should use runtime: go111

### DIFF
--- a/aetest/instance_vm.go
+++ b/aetest/instance_vm.go
@@ -278,7 +278,7 @@ func (i *instance) appYAML() string {
 const appYAMLTemplate = `
 application: %s
 version: 1
-runtime: go
+runtime: go111
 api_version: go1
 
 handlers:

--- a/aetest/instance_vm.go
+++ b/aetest/instance_vm.go
@@ -279,7 +279,6 @@ const appYAMLTemplate = `
 application: %s
 version: 1
 runtime: go111
-api_version: go1
 
 handlers:
 - url: /.*


### PR DESCRIPTION
The aetest displays an error in the new version of App Engine Go Extensions.
I created a pull request because I was able to continue using aetest by setting the runtime to go111.

Before:

```console
$ go test
INFO     2019-10-04 13:15:01,475 devappserver2.py:224] Using Cloud Datastore Emulator.
We are gradually rolling out the emulator as the default datastore implementation of dev_appserver.
If broken, you can temporarily disable it by --support_datastore_emulator=False
Read the documentation: https://cloud.google.com/appengine/docs/standard/python/tools/migrate-cloud-datastore-emulator
Help us validate that the feature is ready by taking this survey: https://goo.gl/forms/UArIcs8K9CUSCm733
Report issues at: https://issuetracker.google.com/issues/new?component=187272

INFO     2019-10-04 13:15:01,490 devappserver2.py:278] Skipping SDK update check.
WARNING  2019-10-04 13:15:01,490 devappserver2.py:294] DEFAULT_VERSION_HOSTNAME will not be set correctly with --port=0
INFO     2019-10-04 13:15:01,736 datastore_emulator.py:155] Starting Cloud Datastore emulator at: http://localhost:21875
WARNING  2019-10-04 13:15:01,738 simple_search_stub.py:1196] Could not read search indexes from /var/folders/wp/wd7n1rkd5ln8v4c3qsw891vnkvjmym/T/appengine.testapp.178inaba/search_indexes
INFO     2019-10-04 13:15:02,998 datastore_emulator.py:161] Cloud Datastore emulator responded after 1.261853 seconds
INFO     2019-10-04 13:15:03,001 api_server.py:275] Starting API server at: http://localhost:56659
INFO     2019-10-04 13:15:03,007 api_server.py:265] Starting gRPC API server at: http://localhost:56661
INFO     2019-10-04 13:15:03,010 stub_util.py:357] Applying all pending transactions and saving the datastore
INFO     2019-10-04 13:15:03,011 stub_util.py:360] Saving search indexes
Traceback (most recent call last):
  File "/Users/178inaba/bin/google-cloud-sdk/platform/google_appengine/dev_appserver.py", line 96, in <module>
    _run_file(__file__, globals())
  File "/Users/178inaba/bin/google-cloud-sdk/platform/google_appengine/dev_appserver.py", line 90, in _run_file
    execfile(_PATHS.script_file(script_name), globals_)
  File "/Users/178inaba/bin/google-cloud-sdk/platform/google_appengine/google/appengine/tools/devappserver2/devappserver2.py", line 600, in <module>
    main()
  File "/Users/178inaba/bin/google-cloud-sdk/platform/google_appengine/google/appengine/tools/devappserver2/devappserver2.py", line 588, in main
    dev_server.start(options)
  File "/Users/178inaba/bin/google-cloud-sdk/platform/google_appengine/google/appengine/tools/devappserver2/devappserver2.py", line 360, in start
    options.api_host, apiserver.port, wsgi_request_info_)
  File "/Users/178inaba/bin/google-cloud-sdk/platform/google_appengine/google/appengine/tools/devappserver2/dispatcher.py", line 248, in start
    ssl_port)
  File "/Users/178inaba/bin/google-cloud-sdk/platform/google_appengine/google/appengine/tools/devappserver2/dispatcher.py", line 384, in _create_module
    ssl_port=ssl_port)
  File "/Users/178inaba/bin/google-cloud-sdk/platform/google_appengine/google/appengine/tools/devappserver2/module.py", line 1309, in __init__
    super(AutoScalingModule, self).__init__(**kwargs)
  File "/Users/178inaba/bin/google-cloud-sdk/platform/google_appengine/google/appengine/tools/devappserver2/module.py", line 598, in __init__
    self._module_configuration)
  File "/Users/178inaba/bin/google-cloud-sdk/platform/google_appengine/google/appengine/tools/devappserver2/module.py", line 231, in _create_instance_factory
    module_configuration=module_configuration)
  File "/Users/178inaba/bin/google-cloud-sdk/platform/google_appengine/google/appengine/tools/devappserver2/go/instance_factory.py", line 137, in __init__
    go_config.enable_debugging)
  File "/Users/178inaba/bin/google-cloud-sdk/platform/google_appengine/google/appengine/tools/devappserver2/go/application.py", line 118, in __init__
    self._arch = self._get_architecture(self._goroot)
  File "/Users/178inaba/bin/google-cloud-sdk/platform/google_appengine/google/appengine/tools/devappserver2/go/application.py", line 212, in _get_architecture
    for platform in os.listdir(os.path.join(goroot, 'pkg', 'tool')):
OSError: [Errno 2] No such file or directory: '/Users/178inaba/bin/google-cloud-sdk/platform/google_appengine/goroot-1.9/pkg/tool'
Exception TypeError: "'NoneType' object is not callable" in <bound method DatastoreEmulator.__del__ of <google.appengine.tools.devappserver2.cloud_emulators.datastore.datastore_emulator.DatastoreEmulator object at 0x109a13e90>> ignored
--- FAIL: TestGitHubStatus (3.01s)
    main_test.go:20: unable to find admin server URL
FAIL
exit status 1
FAIL	github.com/178inaba/aetest-example	3.575s
```

After:

```console
$ go test
INFO     2019-10-04 13:24:30,751 devappserver2.py:224] Using Cloud Datastore Emulator.
We are gradually rolling out the emulator as the default datastore implementation of dev_appserver.
If broken, you can temporarily disable it by --support_datastore_emulator=False
Read the documentation: https://cloud.google.com/appengine/docs/standard/python/tools/migrate-cloud-datastore-emulator
Help us validate that the feature is ready by taking this survey: https://goo.gl/forms/UArIcs8K9CUSCm733
Report issues at: https://issuetracker.google.com/issues/new?component=187272

INFO     2019-10-04 13:24:30,770 devappserver2.py:278] Skipping SDK update check.
WARNING  2019-10-04 13:24:30,770 devappserver2.py:294] DEFAULT_VERSION_HOSTNAME will not be set correctly with --port=0
INFO     2019-10-04 13:24:31,142 datastore_emulator.py:155] Starting Cloud Datastore emulator at: http://localhost:17699
WARNING  2019-10-04 13:24:31,144 simple_search_stub.py:1196] Could not read search indexes from /var/folders/wp/wd7n1rkd5ln8v4c3qsw891vnkvjmym/T/appengine.testapp.178inaba/search_indexes
INFO     2019-10-04 13:24:33,537 datastore_emulator.py:161] Cloud Datastore emulator responded after 2.395747 seconds
INFO     2019-10-04 13:24:33,541 api_server.py:275] Starting API server at: http://localhost:56826
INFO     2019-10-04 13:24:33,551 api_server.py:265] Starting gRPC API server at: http://localhost:56828
INFO     2019-10-04 13:24:33,656 dispatcher.py:256] Starting module "default" running at: http://localhost:56829
INFO     2019-10-04 13:24:33,658 admin_server.py:150] Starting admin server at: http://localhost:56831
INFO     2019-10-04 13:24:35,675 stub_util.py:357] Applying all pending transactions and saving the datastore
INFO     2019-10-04 13:24:35,676 stub_util.py:360] Saving search indexes
Exception TypeError: "'NoneType' object is not callable" in <bound method DatastoreEmulator.__del__ of <google.appengine.tools.devappserver2.cloud_emulators.datastore.datastore_emulator.DatastoreEmulator object at 0x106178e90>> ignored
PASS
ok  	github.com/178inaba/aetest-example	8.864s
```

Tested repository:
https://github.com/178inaba/aetest-example