### PR TITLE
Revert "Remove support for 1.10 and earlier"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,11 @@ script:
 
 matrix:
   include:
+    - go: 1.8.x
+      env: GOAPP=true
+    - go: 1.9.x
+      env: GOAPP=true
+    - go: 1.10.x
+      env: GOAPP=false
     - go: 1.11.x
       env: GO111MODULE=on

--- a/aetest/instance_classic.go
+++ b/aetest/instance_classic.go
@@ -1,0 +1,21 @@
+// +build appengine
+
+package aetest
+
+import "appengine/aetest"
+
+// NewInstance launches a running instance of api_server.py which can be used
+// for multiple test Contexts that delegate all App Engine API calls to that
+// instance.
+// If opts is nil the default values are used.
+func NewInstance(opts *Options) (Instance, error) {
+	aetest.PrepareDevAppserver = PrepareDevAppserver
+	var aeOpts *aetest.Options
+	if opts != nil {
+		aeOpts = &aetest.Options{
+			AppID: opts.AppID,
+			StronglyConsistentDatastore: opts.StronglyConsistentDatastore,
+		}
+	}
+	return aetest.NewInstance(aeOpts)
+}

--- a/appengine.go
+++ b/appengine.go
@@ -61,7 +61,8 @@ func IsDevAppServer() bool {
 }
 
 // IsStandard reports whether the App Engine app is running in the standard
-// environment.
+// environment. This includes both the first generation runtimes (<= Go 1.9)
+// and the second generation runtimes (>= Go 1.11).
 func IsStandard() bool {
 	return internal.IsStandard()
 }

--- a/cloudsql/cloudsql_classic.go
+++ b/cloudsql/cloudsql_classic.go
@@ -1,0 +1,17 @@
+// Copyright 2013 Google Inc. All rights reserved.
+// Use of this source code is governed by the Apache 2.0
+// license that can be found in the LICENSE file.
+
+// +build appengine
+
+package cloudsql
+
+import (
+	"net"
+
+	"appengine/cloudsql"
+)
+
+func connect(instance string) (net.Conn, error) {
+	return cloudsql.Dial(instance)
+}

--- a/internal/api_classic.go
+++ b/internal/api_classic.go
@@ -1,0 +1,169 @@
+// Copyright 2015 Google Inc. All rights reserved.
+// Use of this source code is governed by the Apache 2.0
+// license that can be found in the LICENSE file.
+
+// +build appengine
+
+package internal
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"appengine"
+	"appengine_internal"
+	basepb "appengine_internal/base"
+
+	"github.com/golang/protobuf/proto"
+	netcontext "golang.org/x/net/context"
+)
+
+var contextKey = "holds an appengine.Context"
+
+// fromContext returns the App Engine context or nil if ctx is not
+// derived from an App Engine context.
+func fromContext(ctx netcontext.Context) appengine.Context {
+	c, _ := ctx.Value(&contextKey).(appengine.Context)
+	return c
+}
+
+// This is only for classic App Engine adapters.
+func ClassicContextFromContext(ctx netcontext.Context) (appengine.Context, error) {
+	c := fromContext(ctx)
+	if c == nil {
+		return nil, errNotAppEngineContext
+	}
+	return c, nil
+}
+
+func withContext(parent netcontext.Context, c appengine.Context) netcontext.Context {
+	ctx := netcontext.WithValue(parent, &contextKey, c)
+
+	s := &basepb.StringProto{}
+	c.Call("__go__", "GetNamespace", &basepb.VoidProto{}, s, nil)
+	if ns := s.GetValue(); ns != "" {
+		ctx = NamespacedContext(ctx, ns)
+	}
+
+	return ctx
+}
+
+func IncomingHeaders(ctx netcontext.Context) http.Header {
+	if c := fromContext(ctx); c != nil {
+		if req, ok := c.Request().(*http.Request); ok {
+			return req.Header
+		}
+	}
+	return nil
+}
+
+func ReqContext(req *http.Request) netcontext.Context {
+	return WithContext(netcontext.Background(), req)
+}
+
+func WithContext(parent netcontext.Context, req *http.Request) netcontext.Context {
+	c := appengine.NewContext(req)
+	return withContext(parent, c)
+}
+
+type testingContext struct {
+	appengine.Context
+
+	req *http.Request
+}
+
+func (t *testingContext) FullyQualifiedAppID() string { return "dev~testcontext" }
+func (t *testingContext) Call(service, method string, _, _ appengine_internal.ProtoMessage, _ *appengine_internal.CallOptions) error {
+	if service == "__go__" && method == "GetNamespace" {
+		return nil
+	}
+	return fmt.Errorf("testingContext: unsupported Call")
+}
+func (t *testingContext) Request() interface{} { return t.req }
+
+func ContextForTesting(req *http.Request) netcontext.Context {
+	return withContext(netcontext.Background(), &testingContext{req: req})
+}
+
+func Call(ctx netcontext.Context, service, method string, in, out proto.Message) error {
+	if ns := NamespaceFromContext(ctx); ns != "" {
+		if fn, ok := NamespaceMods[service]; ok {
+			fn(in, ns)
+		}
+	}
+
+	if f, ctx, ok := callOverrideFromContext(ctx); ok {
+		return f(ctx, service, method, in, out)
+	}
+
+	// Handle already-done contexts quickly.
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
+	c := fromContext(ctx)
+	if c == nil {
+		// Give a good error message rather than a panic lower down.
+		return errNotAppEngineContext
+	}
+
+	// Apply transaction modifications if we're in a transaction.
+	if t := transactionFromContext(ctx); t != nil {
+		if t.finished {
+			return errors.New("transaction context has expired")
+		}
+		applyTransaction(in, &t.transaction)
+	}
+
+	var opts *appengine_internal.CallOptions
+	if d, ok := ctx.Deadline(); ok {
+		opts = &appengine_internal.CallOptions{
+			Timeout: d.Sub(time.Now()),
+		}
+	}
+
+	err := c.Call(service, method, in, out, opts)
+	switch v := err.(type) {
+	case *appengine_internal.APIError:
+		return &APIError{
+			Service: v.Service,
+			Detail:  v.Detail,
+			Code:    v.Code,
+		}
+	case *appengine_internal.CallError:
+		return &CallError{
+			Detail:  v.Detail,
+			Code:    v.Code,
+			Timeout: v.Timeout,
+		}
+	}
+	return err
+}
+
+func handleHTTP(w http.ResponseWriter, r *http.Request) {
+	panic("handleHTTP called; this should be impossible")
+}
+
+func logf(c appengine.Context, level int64, format string, args ...interface{}) {
+	var fn func(format string, args ...interface{})
+	switch level {
+	case 0:
+		fn = c.Debugf
+	case 1:
+		fn = c.Infof
+	case 2:
+		fn = c.Warningf
+	case 3:
+		fn = c.Errorf
+	case 4:
+		fn = c.Criticalf
+	default:
+		// This shouldn't happen.
+		fn = c.Criticalf
+	}
+	fn(format, args...)
+}

--- a/internal/identity.go
+++ b/internal/identity.go
@@ -11,6 +11,12 @@ import (
 )
 
 var (
+	// This is set to true in identity_classic.go, which is behind the appengine build tag.
+	// The appengine build tag is set for the first generation runtimes (<= Go 1.9) but not
+	// the second generation runtimes (>= Go 1.11), so this indicates whether we're on a
+	// first-gen runtime. See IsStandard below for the second-gen check.
+	appengineStandard bool
+
 	// This is set to true in identity_flex.go, which is behind the appenginevm build tag.
 	appengineFlex bool
 )
@@ -24,10 +30,12 @@ func AppID(c netcontext.Context) string {
 // IsStandard is the implementation of the wrapper function of the same name in
 // ../appengine.go. See that file for commentary.
 func IsStandard() bool {
-	return IsSecondGen()
+	// appengineStandard will be true for first-gen runtimes (<= Go 1.9) but not
+	// second-gen (>= Go 1.11).
+	return appengineStandard || IsSecondGen()
 }
 
-// IsSecondGen is the implementation of the wrapper function of the same name in
+// IsStandard is the implementation of the wrapper function of the same name in
 // ../appengine.go. See that file for commentary.
 func IsSecondGen() bool {
 	// Second-gen runtimes set $GAE_ENV so we use that to check if we're on a second-gen runtime.

--- a/internal/identity_classic.go
+++ b/internal/identity_classic.go
@@ -1,0 +1,61 @@
+// Copyright 2015 Google Inc. All rights reserved.
+// Use of this source code is governed by the Apache 2.0
+// license that can be found in the LICENSE file.
+
+// +build appengine
+
+package internal
+
+import (
+	"appengine"
+
+	netcontext "golang.org/x/net/context"
+)
+
+func init() {
+	appengineStandard = true
+}
+
+func DefaultVersionHostname(ctx netcontext.Context) string {
+	c := fromContext(ctx)
+	if c == nil {
+		panic(errNotAppEngineContext)
+	}
+	return appengine.DefaultVersionHostname(c)
+}
+
+func Datacenter(_ netcontext.Context) string { return appengine.Datacenter() }
+func ServerSoftware() string                 { return appengine.ServerSoftware() }
+func InstanceID() string                     { return appengine.InstanceID() }
+func IsDevAppServer() bool                   { return appengine.IsDevAppServer() }
+
+func RequestID(ctx netcontext.Context) string {
+	c := fromContext(ctx)
+	if c == nil {
+		panic(errNotAppEngineContext)
+	}
+	return appengine.RequestID(c)
+}
+
+func ModuleName(ctx netcontext.Context) string {
+	c := fromContext(ctx)
+	if c == nil {
+		panic(errNotAppEngineContext)
+	}
+	return appengine.ModuleName(c)
+}
+func VersionID(ctx netcontext.Context) string {
+	c := fromContext(ctx)
+	if c == nil {
+		panic(errNotAppEngineContext)
+	}
+	return appengine.VersionID(c)
+}
+
+func fullyQualifiedAppID(ctx netcontext.Context) string {
+	c := fromContext(ctx)
+	if c == nil {
+		panic(errNotAppEngineContext)
+	}
+	return c.FullyQualifiedAppID()
+}

--- a/internal/main.go
+++ b/internal/main.go
@@ -1,0 +1,16 @@
+// Copyright 2011 Google Inc. All rights reserved.
+// Use of this source code is governed by the Apache 2.0
+// license that can be found in the LICENSE file.
+
+// +build appengine
+
+package internal
+
+import (
+	"appengine_internal"
+)
+
+func Main() {
+	MainPath = ""
+	appengine_internal.Main()
+}

--- a/socket/socket_classic.go
+++ b/socket/socket_classic.go
@@ -1,0 +1,290 @@
+// Copyright 2012 Google Inc. All rights reserved.
+// Use of this source code is governed by the Apache 2.0
+// license that can be found in the LICENSE file.
+
+// +build appengine
+
+package socket
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"strconv"
+	"time"
+
+	"github.com/golang/protobuf/proto"
+	"golang.org/x/net/context"
+	"google.golang.org/appengine/internal"
+
+	pb "google.golang.org/appengine/internal/socket"
+)
+
+// Dial connects to the address addr on the network protocol.
+// The address format is host:port, where host may be a hostname or an IP address.
+// Known protocols are "tcp" and "udp".
+// The returned connection satisfies net.Conn, and is valid while ctx is valid;
+// if the connection is to be used after ctx becomes invalid, invoke SetContext
+// with the new context.
+func Dial(ctx context.Context, protocol, addr string) (*Conn, error) {
+	return DialTimeout(ctx, protocol, addr, 0)
+}
+
+var ipFamilies = []pb.CreateSocketRequest_SocketFamily{
+	pb.CreateSocketRequest_IPv4,
+	pb.CreateSocketRequest_IPv6,
+}
+
+// DialTimeout is like Dial but takes a timeout.
+// The timeout includes name resolution, if required.
+func DialTimeout(ctx context.Context, protocol, addr string, timeout time.Duration) (*Conn, error) {
+	dialCtx := ctx // Used for dialing and name resolution, but not stored in the *Conn.
+	if timeout > 0 {
+		var cancel context.CancelFunc
+		dialCtx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
+
+	host, portStr, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, err
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		return nil, fmt.Errorf("socket: bad port %q: %v", portStr, err)
+	}
+
+	var prot pb.CreateSocketRequest_SocketProtocol
+	switch protocol {
+	case "tcp":
+		prot = pb.CreateSocketRequest_TCP
+	case "udp":
+		prot = pb.CreateSocketRequest_UDP
+	default:
+		return nil, fmt.Errorf("socket: unknown protocol %q", protocol)
+	}
+
+	packedAddrs, resolved, err := resolve(dialCtx, ipFamilies, host)
+	if err != nil {
+		return nil, fmt.Errorf("socket: failed resolving %q: %v", host, err)
+	}
+	if len(packedAddrs) == 0 {
+		return nil, fmt.Errorf("no addresses for %q", host)
+	}
+
+	packedAddr := packedAddrs[0] // use first address
+	fam := pb.CreateSocketRequest_IPv4
+	if len(packedAddr) == net.IPv6len {
+		fam = pb.CreateSocketRequest_IPv6
+	}
+
+	req := &pb.CreateSocketRequest{
+		Family:   fam.Enum(),
+		Protocol: prot.Enum(),
+		RemoteIp: &pb.AddressPort{
+			Port:          proto.Int32(int32(port)),
+			PackedAddress: packedAddr,
+		},
+	}
+	if resolved {
+		req.RemoteIp.HostnameHint = &host
+	}
+	res := &pb.CreateSocketReply{}
+	if err := internal.Call(dialCtx, "remote_socket", "CreateSocket", req, res); err != nil {
+		return nil, err
+	}
+
+	return &Conn{
+		ctx:    ctx,
+		desc:   res.GetSocketDescriptor(),
+		prot:   prot,
+		local:  res.ProxyExternalIp,
+		remote: req.RemoteIp,
+	}, nil
+}
+
+// LookupIP returns the given host's IP addresses.
+func LookupIP(ctx context.Context, host string) (addrs []net.IP, err error) {
+	packedAddrs, _, err := resolve(ctx, ipFamilies, host)
+	if err != nil {
+		return nil, fmt.Errorf("socket: failed resolving %q: %v", host, err)
+	}
+	addrs = make([]net.IP, len(packedAddrs))
+	for i, pa := range packedAddrs {
+		addrs[i] = net.IP(pa)
+	}
+	return addrs, nil
+}
+
+func resolve(ctx context.Context, fams []pb.CreateSocketRequest_SocketFamily, host string) ([][]byte, bool, error) {
+	// Check if it's an IP address.
+	if ip := net.ParseIP(host); ip != nil {
+		if ip := ip.To4(); ip != nil {
+			return [][]byte{ip}, false, nil
+		}
+		return [][]byte{ip}, false, nil
+	}
+
+	req := &pb.ResolveRequest{
+		Name:            &host,
+		AddressFamilies: fams,
+	}
+	res := &pb.ResolveReply{}
+	if err := internal.Call(ctx, "remote_socket", "Resolve", req, res); err != nil {
+		// XXX: need to map to pb.ResolveReply_ErrorCode?
+		return nil, false, err
+	}
+	return res.PackedAddress, true, nil
+}
+
+// withDeadline is like context.WithDeadline, except it ignores the zero deadline.
+func withDeadline(parent context.Context, deadline time.Time) (context.Context, context.CancelFunc) {
+	if deadline.IsZero() {
+		return parent, func() {}
+	}
+	return context.WithDeadline(parent, deadline)
+}
+
+// Conn represents a socket connection.
+// It implements net.Conn.
+type Conn struct {
+	ctx    context.Context
+	desc   string
+	offset int64
+
+	prot          pb.CreateSocketRequest_SocketProtocol
+	local, remote *pb.AddressPort
+
+	readDeadline, writeDeadline time.Time // optional
+}
+
+// SetContext sets the context that is used by this Conn.
+// It is usually used only when using a Conn that was created in a different context,
+// such as when a connection is created during a warmup request but used while
+// servicing a user request.
+func (cn *Conn) SetContext(ctx context.Context) {
+	cn.ctx = ctx
+}
+
+func (cn *Conn) Read(b []byte) (n int, err error) {
+	const maxRead = 1 << 20
+	if len(b) > maxRead {
+		b = b[:maxRead]
+	}
+
+	req := &pb.ReceiveRequest{
+		SocketDescriptor: &cn.desc,
+		DataSize:         proto.Int32(int32(len(b))),
+	}
+	res := &pb.ReceiveReply{}
+	if !cn.readDeadline.IsZero() {
+		req.TimeoutSeconds = proto.Float64(cn.readDeadline.Sub(time.Now()).Seconds())
+	}
+	ctx, cancel := withDeadline(cn.ctx, cn.readDeadline)
+	defer cancel()
+	if err := internal.Call(ctx, "remote_socket", "Receive", req, res); err != nil {
+		return 0, err
+	}
+	if len(res.Data) == 0 {
+		return 0, io.EOF
+	}
+	if len(res.Data) > len(b) {
+		return 0, fmt.Errorf("socket: internal error: read too much data: %d > %d", len(res.Data), len(b))
+	}
+	return copy(b, res.Data), nil
+}
+
+func (cn *Conn) Write(b []byte) (n int, err error) {
+	const lim = 1 << 20 // max per chunk
+
+	for n < len(b) {
+		chunk := b[n:]
+		if len(chunk) > lim {
+			chunk = chunk[:lim]
+		}
+
+		req := &pb.SendRequest{
+			SocketDescriptor: &cn.desc,
+			Data:             chunk,
+			StreamOffset:     &cn.offset,
+		}
+		res := &pb.SendReply{}
+		if !cn.writeDeadline.IsZero() {
+			req.TimeoutSeconds = proto.Float64(cn.writeDeadline.Sub(time.Now()).Seconds())
+		}
+		ctx, cancel := withDeadline(cn.ctx, cn.writeDeadline)
+		defer cancel()
+		if err = internal.Call(ctx, "remote_socket", "Send", req, res); err != nil {
+			// assume zero bytes were sent in this RPC
+			break
+		}
+		n += int(res.GetDataSent())
+		cn.offset += int64(res.GetDataSent())
+	}
+
+	return
+}
+
+func (cn *Conn) Close() error {
+	req := &pb.CloseRequest{
+		SocketDescriptor: &cn.desc,
+	}
+	res := &pb.CloseReply{}
+	if err := internal.Call(cn.ctx, "remote_socket", "Close", req, res); err != nil {
+		return err
+	}
+	cn.desc = "CLOSED"
+	return nil
+}
+
+func addr(prot pb.CreateSocketRequest_SocketProtocol, ap *pb.AddressPort) net.Addr {
+	if ap == nil {
+		return nil
+	}
+	switch prot {
+	case pb.CreateSocketRequest_TCP:
+		return &net.TCPAddr{
+			IP:   net.IP(ap.PackedAddress),
+			Port: int(*ap.Port),
+		}
+	case pb.CreateSocketRequest_UDP:
+		return &net.UDPAddr{
+			IP:   net.IP(ap.PackedAddress),
+			Port: int(*ap.Port),
+		}
+	}
+	panic("unknown protocol " + prot.String())
+}
+
+func (cn *Conn) LocalAddr() net.Addr  { return addr(cn.prot, cn.local) }
+func (cn *Conn) RemoteAddr() net.Addr { return addr(cn.prot, cn.remote) }
+
+func (cn *Conn) SetDeadline(t time.Time) error {
+	cn.readDeadline = t
+	cn.writeDeadline = t
+	return nil
+}
+
+func (cn *Conn) SetReadDeadline(t time.Time) error {
+	cn.readDeadline = t
+	return nil
+}
+
+func (cn *Conn) SetWriteDeadline(t time.Time) error {
+	cn.writeDeadline = t
+	return nil
+}
+
+// KeepAlive signals that the connection is still in use.
+// It may be called to prevent the socket being closed due to inactivity.
+func (cn *Conn) KeepAlive() error {
+	req := &pb.GetSocketNameRequest{
+		SocketDescriptor: &cn.desc,
+	}
+	res := &pb.GetSocketNameReply{}
+	return internal.Call(cn.ctx, "remote_socket", "GetSocketName", req, res)
+}
+
+func init() {
+	internal.RegisterErrorCodeMap("remote_socket", pb.RemoteSocketServiceError_ErrorCode_name)
+}

--- a/travis_install.sh
+++ b/travis_install.sh
@@ -6,3 +6,13 @@ if [[ $GO111MODULE == "on" ]]; then
 else
   go get -u -v $(go list -f '{{join .Imports "\n"}}{{"\n"}}{{join .TestImports "\n"}}' ./... | sort | uniq | grep -v appengine)
 fi
+
+if [[ $GOAPP == "true" ]]; then
+  mkdir /tmp/sdk
+  curl -o /tmp/sdk.zip "https://storage.googleapis.com/appengine-sdks/featured/go_appengine_sdk_linux_amd64-1.9.68.zip"
+  unzip -q /tmp/sdk.zip -d /tmp/sdk
+  # NOTE: Set the following env vars in the test script:
+  # export PATH="$PATH:/tmp/sdk/go_appengine"
+  # export APPENGINE_DEV_APPSERVER=/tmp/sdk/go_appengine/dev_appserver.py
+fi
+

--- a/travis_test.sh
+++ b/travis_test.sh
@@ -4,3 +4,9 @@ set -e
 go version
 go test -v google.golang.org/appengine/...
 go test -v -race google.golang.org/appengine/...
+if [[ $GOAPP == "true" ]]; then
+  export PATH="$PATH:/tmp/sdk/go_appengine"
+  export APPENGINE_DEV_APPSERVER=/tmp/sdk/go_appengine/dev_appserver.py
+  goapp version
+  goapp test -v google.golang.org/appengine/...
+fi

--- a/user/user_classic.go
+++ b/user/user_classic.go
@@ -1,0 +1,44 @@
+// Copyright 2015 Google Inc. All rights reserved.
+// Use of this source code is governed by the Apache 2.0
+// license that can be found in the LICENSE file.
+
+// +build appengine
+
+package user
+
+import (
+	"appengine/user"
+
+	"golang.org/x/net/context"
+
+	"google.golang.org/appengine/internal"
+)
+
+func Current(ctx context.Context) *User {
+	c, err := internal.ClassicContextFromContext(ctx)
+	if err != nil {
+		panic(err)
+	}
+	u := user.Current(c)
+	if u == nil {
+		return nil
+	}
+	// Map appengine/user.User to this package's User type.
+	return &User{
+		Email:             u.Email,
+		AuthDomain:        u.AuthDomain,
+		Admin:             u.Admin,
+		ID:                u.ID,
+		FederatedIdentity: u.FederatedIdentity,
+		FederatedProvider: u.FederatedProvider,
+	}
+}
+
+func IsAdmin(ctx context.Context) bool {
+	c, err := internal.ClassicContextFromContext(ctx)
+	if err != nil {
+		panic(err)
+	}
+
+	return user.IsAdmin(c)
+}


### PR DESCRIPTION
Reverts golang/appengine#217 -- breaks tests downstream. Will reland once we've migrated those affected (likely O(weeks) time)