### PR TITLE
[internal] Optimize HTTP transport params

### DIFF
--- a/internal/api.go
+++ b/internal/api.go
@@ -58,8 +58,11 @@ var (
 
 	apiHTTPClient = &http.Client{
 		Transport: &http.Transport{
-			Proxy: http.ProxyFromEnvironment,
-			Dial:  limitDial,
+			Proxy:               http.ProxyFromEnvironment,
+			Dial:                limitDial,
+			MaxIdleConns:        1000,
+			MaxIdleConnsPerHost: 10000,
+			IdleConnTimeout:     90 * time.Second,
 		},
 	}
 


### PR DESCRIPTION
Since these calls are all made to the same host, persisting connections
and specifying the timeouts yields performance and throughput improvements.