### PR TITLE
[aetest] Allow specifying path to dev_appserver binary

### DIFF
--- a/aetest/instance_vm.go
+++ b/aetest/instance_vm.go
@@ -163,7 +163,7 @@ func (i *instance) startChild() (err error) {
 	executable := os.Getenv("APPENGINE_DEV_APPSERVER_BINARY")
 	var appserverArgs []string
 	if len(executable) == 0 {
-		executable, err := findPython()
+		executable, err = findPython()
 		if err != nil {
 			return fmt.Errorf("Could not find python interpreter: %v", err)
 		}

--- a/aetest/instance_vm.go
+++ b/aetest/instance_vm.go
@@ -39,10 +39,6 @@ func NewInstance(opts *Options) (Instance, error) {
 			i.startupTimeout = opts.StartupTimeout
 		}
 	}
-	if len(os.Getenv("APPENGINE_DEV_APPSERVER_BINARY")) > 0 {
-		os.Setenv("APPENGINE_DEV_APPSERVER", os.Getenv("APPENGINE_DEV_APPSERVER_BINARY"))
-		PrepareDevAppserver = nil
-	}
 	if err := i.startChild(); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
by setting the environment variable "APPENGINE_DEV_APPSERVER_BINARY" to the path of an executable file, `aetest` will now use it to launch the devappserver.