### PR TITLE
[atest] Specify path to dev_appserver datastore file via APPENGINE_DEV_APPSERVER_DATASTORE_PATH

### DIFF
--- a/aetest/instance_vm.go
+++ b/aetest/instance_vm.go
@@ -192,6 +192,11 @@ func (i *instance) startChild() (err error) {
 		return err
 	}
 
+	datastore_path := os.Getenv("APPENGINE_DEV_APPSERVER_DATASTORE_PATH")
+	if len(datastore_path) == 0 {
+		datastore_path = filepath.Join(i.appDir, "datastore")
+	}
+
 	appserverArgs = append(appserverArgs,
 		"--port=0",
 		"--api_port=0",
@@ -200,7 +205,7 @@ func (i *instance) startChild() (err error) {
 		"--skip_sdk_update_check=true",
 		"--clear_datastore=true",
 		"--clear_search_indexes=true",
-		"--datastore_path", filepath.Join(i.appDir, "datastore"),
+		"--datastore_path", datastore_path,
 	)
 	if i.opts != nil && i.opts.StronglyConsistentDatastore {
 		appserverArgs = append(appserverArgs, "--datastore_consistency_policy=consistent")

--- a/aetest/instance_vm.go
+++ b/aetest/instance_vm.go
@@ -192,9 +192,9 @@ func (i *instance) startChild() (err error) {
 		return err
 	}
 
-	datastore_path := os.Getenv("APPENGINE_DEV_APPSERVER_DATASTORE_PATH")
-	if len(datastore_path) == 0 {
-		datastore_path = filepath.Join(i.appDir, "datastore")
+	datastorePath := os.Getenv("APPENGINE_DEV_APPSERVER_DATASTORE_PATH")
+	if len(datastorePath) == 0 {
+		datastorePath = filepath.Join(i.appDir, "datastore")
 	}
 
 	appserverArgs = append(appserverArgs,
@@ -205,7 +205,7 @@ func (i *instance) startChild() (err error) {
 		"--skip_sdk_update_check=true",
 		"--clear_datastore=true",
 		"--clear_search_indexes=true",
-		"--datastore_path", datastore_path,
+		"--datastore_path", datastorePath,
 	)
 	if i.opts != nil && i.opts.StronglyConsistentDatastore {
 		appserverArgs = append(appserverArgs, "--datastore_consistency_policy=consistent")


### PR DESCRIPTION
If the environment variable `APPENGINE_DEV_APPSERVER_DATASTORE_PATH` is set, use it as the path to the dev_appserver datastore file, rather than the default of `filepath.Join(i.appDir, "datastore")`