### PR TITLE
Fix header name to associate log entry & trace

### DIFF
--- a/v2/internal/log.go
+++ b/v2/internal/log.go
@@ -108,7 +108,7 @@ func chunkLog(msg string) []string {
 }
 
 func traceAndSpan(c *context) (string, string) {
-	headers := c.req.Header["Cloud-Trace-Context"]
+	headers := c.req.Header["X-Cloud-Trace-Context"]
 	if len(headers) < 1 {
 		return "", ""
 	}

--- a/v2/internal/log_test.go
+++ b/v2/internal/log_test.go
@@ -437,7 +437,7 @@ func buildContextWithTraceHeaders(t *testing.T, headers []string) *context {
 		t.Fatal(err)
 	}
 	for _, h := range headers {
-		req.Header.Add("Cloud-Trace-Context", h)
+		req.Header.Add("X-Cloud-Trace-Context", h)
 	}
 	return fromContext(ContextForTesting(req))
 }


### PR DESCRIPTION
Thanks for releasing v2.
I tried the log API on GAE 2nd gen, but it didn't associate with the request log.
The request header to get a trace id and a span id is correct `X-Cloud-Trace-Context`, not `Cloud-Trace-Context`.