### PR TITLE
switch default logStream from stdout to stderr

### DIFF
--- a/v2/internal/api.go
+++ b/v2/internal/api.go
@@ -67,7 +67,7 @@ var (
 	backgroundContextOnce sync.Once
 	backgroundContext     netcontext.Context
 
-	logStream io.Writer        = os.Stdout // For test hooks.
+	logStream io.Writer        = os.Stderr // For test hooks.
 	timeNow   func() time.Time = time.Now  // For test hooks.
 )
 


### PR DESCRIPTION
For consistency with go's std logging package, work being done in the Python and Java GAE runtimes, and general posix conventions.