### PR TITLE
Pin setup-gcloud to v0 instead of master

### DIFF
--- a/.github/workflows/ci-v2.yaml
+++ b/.github/workflows/ci-v2.yaml
@@ -32,7 +32,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-${{ matrix.go-version }}-go-
     - name: Set up Cloud SDK
-      uses: google-github-actions/setup-gcloud@master
+      uses: google-github-actions/setup-gcloud@v0
     - name: Install
       working-directory: ${{env.working-directory}}
       env:
@@ -49,7 +49,7 @@ jobs:
         go test -v -cover -race google.golang.org/appengine/v2/...
         # TestAPICallAllocations doesn't run under race detector.
         go test -v -cover google.golang.org/appengine/v2/internal/... -run TestAPICallAllocations
-  
+
   test-gopath-v2:
     runs-on: ubuntu-latest
     strategy:
@@ -58,7 +58,7 @@ jobs:
         go-version: [ '1.11.x', '1.12.x']
     env:
       working-directory: ./v2
-    
+
     steps:
     - name: Set up Go
       uses: actions/setup-go@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-${{ matrix.go-version }}-go-
     - name: Set up Cloud SDK
-      uses: google-github-actions/setup-gcloud@master
+      uses: google-github-actions/setup-gcloud@v0
     - name: Install
       env:
         GO111MODULE: on
@@ -45,7 +45,7 @@ jobs:
         go test -v -cover -race google.golang.org/appengine/...
         # TestAPICallAllocations doesn't run under race detector.
         go test -v -cover google.golang.org/appengine/internal/... -run TestAPICallAllocations
-  
+
   test-gopath:
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
setup-gcloud will be updating the branch name from master to main in
a future release. Even though GitHub will establish redirects, this
will break any GitHub Actions workflows that pin to master. This PR
updates your GitHub Actions workflows to pin to v0, which is the
recommended best practice.