### PR TITLE
Fix golang/appengine CI

### DIFF
--- a/.github/workflows/ci-v2.yaml
+++ b/.github/workflows/ci-v2.yaml
@@ -32,7 +32,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-${{ matrix.go-version }}-go-
     - name: Set up Cloud SDK
-      uses: google-github-actions/setup-gcloud@master
+      uses: google-github-actions/setup-gcloud@v0
     - name: Install
       working-directory: ${{env.working-directory}}
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-${{ matrix.go-version }}-go-
     - name: Set up Cloud SDK
-      uses: google-github-actions/setup-gcloud@master
+      uses: google-github-actions/setup-gcloud@v0
     - name: Install
       env:
         GO111MODULE: on


### PR DESCRIPTION
With google-github-actions/setup-gcloud#539, they broke Github workflows specifying the "master" branch ahead of the rename of the branch to 'main'.