### PR TITLE
run gofmt with go1.19 release candidate

### DIFF
--- a/aetest/instance_classic.go
+++ b/aetest/instance_classic.go
@@ -1,3 +1,4 @@
+//go:build appengine
 // +build appengine
 
 package aetest
@@ -13,7 +14,7 @@ func NewInstance(opts *Options) (Instance, error) {
 	var aeOpts *aetest.Options
 	if opts != nil {
 		aeOpts = &aetest.Options{
-			AppID: opts.AppID,
+			AppID:                       opts.AppID,
 			StronglyConsistentDatastore: opts.StronglyConsistentDatastore,
 		}
 	}

--- a/aetest/instance_vm.go
+++ b/aetest/instance_vm.go
@@ -1,3 +1,4 @@
+//go:build !appengine
 // +build !appengine
 
 package aetest

--- a/appengine.go
+++ b/appengine.go
@@ -35,18 +35,18 @@ import (
 //
 // Main is designed so that the app's main package looks like this:
 //
-//      package main
+//	package main
 //
-//      import (
-//              "google.golang.org/appengine"
+//	import (
+//	        "google.golang.org/appengine"
 //
-//              _ "myapp/package0"
-//              _ "myapp/package1"
-//      )
+//	        _ "myapp/package0"
+//	        _ "myapp/package1"
+//	)
 //
-//      func main() {
-//              appengine.Main()
-//      }
+//	func main() {
+//	        appengine.Main()
+//	}
 //
 // The "myapp/packageX" packages are expected to register HTTP handlers
 // in their init functions.

--- a/appengine_vm.go
+++ b/appengine_vm.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by the Apache 2.0
 // license that can be found in the LICENSE file.
 
+//go:build !appengine
 // +build !appengine
 
 package appengine

--- a/capability/capability.go
+++ b/capability/capability.go
@@ -9,6 +9,7 @@ for specific API capabilities.
 This package does not work in App Engine "flexible environment".
 
 Example:
+
 	if !capability.Enabled(c, "datastore_v3", "write") {
 		// show user a different page
 	}

--- a/cloudsql/cloudsql.go
+++ b/cloudsql/cloudsql.go
@@ -14,18 +14,18 @@ with protocol "cloudsql" and an address of the Cloud SQL instance.
 
 A Go MySQL driver that has been tested to work well with Cloud SQL
 is the go-sql-driver:
+
 	import "database/sql"
 	import _ "github.com/go-sql-driver/mysql"
 
 	db, err := sql.Open("mysql", "user@cloudsql(project-id:instance-name)/dbname")
 
-
 Another driver that works well with Cloud SQL is the mymysql driver:
+
 	import "database/sql"
 	import _ "github.com/ziutek/mymysql/godrv"
 
 	db, err := sql.Open("mymysql", "cloudsql:instance-name*dbname/user/password")
-
 
 Using either of these drivers, you can perform a standard SQL query.
 This example assumes there is a table named 'users' with

--- a/cloudsql/cloudsql_classic.go
+++ b/cloudsql/cloudsql_classic.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by the Apache 2.0
 // license that can be found in the LICENSE file.
 
+//go:build appengine
 // +build appengine
 
 package cloudsql

--- a/cloudsql/cloudsql_vm.go
+++ b/cloudsql/cloudsql_vm.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by the Apache 2.0
 // license that can be found in the LICENSE file.
 
+//go:build !appengine
 // +build !appengine
 
 package cloudsql

--- a/cmd/aebundler/aebundler.go
+++ b/cmd/aebundler/aebundler.go
@@ -8,9 +8,10 @@
 // A main func is synthesized if one does not exist.
 //
 // A sample Dockerfile to be used with this bundler could look like this:
-//     FROM gcr.io/google-appengine/go-compat
-//     ADD . /app
-//     RUN GOPATH=/app/_gopath go build -tags appenginevm -o /app/_ah/exe
+//
+//	FROM gcr.io/google-appengine/go-compat
+//	ADD . /app
+//	RUN GOPATH=/app/_gopath go build -tags appenginevm -o /app/_ah/exe
 package main
 
 import (

--- a/datastore/doc.go
+++ b/datastore/doc.go
@@ -5,8 +5,7 @@
 /*
 Package datastore provides a client for App Engine's datastore service.
 
-
-Basic Operations
+# Basic Operations
 
 Entities are the unit of storage and are associated with a key. A key
 consists of an optional parent key, a string application ID, a string kind
@@ -74,8 +73,7 @@ GetMulti, PutMulti and DeleteMulti are batch versions of the Get, Put and
 Delete functions. They take a []*Key instead of a *Key, and may return an
 appengine.MultiError when encountering partial failure.
 
-
-Properties
+# Properties
 
 An entity's contents can be represented by a variety of types. These are
 typically struct pointers, but can also be any type that implements the
@@ -137,8 +135,7 @@ Example code:
 		J int `datastore:",noindex" json:"j"`
 	}
 
-
-Structured Properties
+# Structured Properties
 
 If the struct pointed to contains other structs, then the nested or embedded
 structs are flattened. For example, given these definitions:
@@ -179,8 +176,7 @@ equivalent field would instead be: FooDotZ bool `datastore:"Foo.Z"`.
 If an outer struct is tagged "noindex" then all of its implicit flattened
 fields are effectively "noindex".
 
-
-The PropertyLoadSaver Interface
+# The PropertyLoadSaver Interface
 
 An entity's contents can also be represented by any type that implements the
 PropertyLoadSaver interface. This type may be a struct pointer, but it does
@@ -230,8 +226,7 @@ Example code:
 The *PropertyList type implements PropertyLoadSaver, and can therefore hold an
 arbitrary entity's contents.
 
-
-Queries
+# Queries
 
 Queries retrieve entities based on their properties or key's ancestry. Running
 a query yields an iterator of results: either keys or (key, entity) pairs.
@@ -284,8 +279,7 @@ Example code:
 		io.Copy(w, b)
 	}
 
-
-Transactions
+# Transactions
 
 RunInTransaction runs a function in a transaction.
 
@@ -323,8 +317,7 @@ Example code:
 		fmt.Fprintf(w, "Count=%d", count)
 	}
 
-
-Metadata
+# Metadata
 
 The datastore package provides access to some of App Engine's datastore
 metadata. This metadata includes information about the entity groups,

--- a/datastore/metadata.go
+++ b/datastore/metadata.go
@@ -50,13 +50,14 @@ func keyNames(keys []*Key) []string {
 // The properties are returned as a map of property names to a slice of the
 // representation types. The representation types for the supported Go property
 // types are:
-//   "INT64":     signed integers and time.Time
-//   "DOUBLE":    float32 and float64
-//   "BOOLEAN":   bool
-//   "STRING":    string, []byte and ByteString
-//   "POINT":     appengine.GeoPoint
-//   "REFERENCE": *Key
-//   "USER":      (not used in the Go runtime)
+//
+//	"INT64":     signed integers and time.Time
+//	"DOUBLE":    float32 and float64
+//	"BOOLEAN":   bool
+//	"STRING":    string, []byte and ByteString
+//	"POINT":     appengine.GeoPoint
+//	"REFERENCE": *Key
+//	"USER":      (not used in the Go runtime)
 func KindProperties(ctx context.Context, kind string) (map[string][]string, error) {
 	// TODO(djd): Support range queries.
 	kindKey := NewKey(ctx, kindKind, kind, 0, nil)

--- a/datastore/query.go
+++ b/datastore/query.go
@@ -476,7 +476,7 @@ func callNext(c context.Context, res *pb.QueryResult, offset, count int32) error
 // The keys returned by GetAll will be in a 1-1 correspondence with the entities
 // added to dst.
 //
-// If q is a ``keys-only'' query, GetAll ignores dst and only returns the keys.
+// If q is a “keys-only” query, GetAll ignores dst and only returns the keys.
 //
 // The running time and number of API calls made by GetAll scale linearly with
 // the sum of the query's offset and limit. Unless the result count is

--- a/delay/delay.go
+++ b/delay/delay.go
@@ -10,14 +10,19 @@ To declare a function that may be executed later, call Func
 in a top-level assignment context, passing it an arbitrary string key
 and a function whose first argument is of type context.Context.
 The key is used to look up the function so it can be called later.
+
 	var laterFunc = delay.Func("key", myFunc)
+
 It is also possible to use a function literal.
+
 	var laterFunc = delay.Func("key", func(c context.Context, x string) {
 		// ...
 	})
 
 To call a function, invoke its Call method.
+
 	laterFunc.Call(c, "something")
+
 A function may be called any number of times. If the function has any
 return arguments, and the last one is of type error, the function may
 return a non-nil error to signal that the function should be retried.
@@ -37,9 +42,9 @@ with the string key that was passed to the Func function. Updating an app
 with pending function invocations should safe as long as the relevant
 functions have the (filename, key) combination preserved. The filename is
 parsed according to these rules:
-  * Paths in package main are shortened to just the file name (github.com/foo/foo.go -> foo.go)
-  * Paths are stripped to just package paths (/go/src/github.com/foo/bar.go -> github.com/foo/bar.go)
-  * Module versions are stripped (/go/pkg/mod/github.com/foo/bar@v0.0.0-20181026220418-f595d03440dc/baz.go -> github.com/foo/bar/baz.go)
+  - Paths in package main are shortened to just the file name (github.com/foo/foo.go -> foo.go)
+  - Paths are stripped to just package paths (/go/src/github.com/foo/bar.go -> github.com/foo/bar.go)
+  - Module versions are stripped (/go/pkg/mod/github.com/foo/bar@v0.0.0-20181026220418-f595d03440dc/baz.go -> github.com/foo/bar/baz.go)
 
 There is some inherent risk of pending function invocations being lost during
 an update that contains large changes. For example, switching from using GOPATH
@@ -208,10 +213,13 @@ type invocation struct {
 }
 
 // Call invokes a delayed function.
-//   err := f.Call(c, ...)
+//
+//	err := f.Call(c, ...)
+//
 // is equivalent to
-//   t, _ := f.Task(...)
-//   _, err := taskqueue.Add(c, t, "")
+//
+//	t, _ := f.Task(...)
+//	_, err := taskqueue.Add(c, t, "")
 func (f *Function) Call(c context.Context, args ...interface{}) error {
 	t, err := f.Task(args...)
 	if err != nil {

--- a/demos/guestbook/guestbook.go
+++ b/demos/guestbook/guestbook.go
@@ -3,6 +3,7 @@
 // license that can be found in the LICENSE file.
 
 // This example only works on App Engine "flexible environment".
+//go:build !appengine
 // +build !appengine
 
 package main

--- a/demos/helloworld/helloworld.go
+++ b/demos/helloworld/helloworld.go
@@ -3,6 +3,7 @@
 // license that can be found in the LICENSE file.
 
 // This example only works on App Engine "flexible environment".
+//go:build !appengine
 // +build !appengine
 
 package main

--- a/internal/api.go
+++ b/internal/api.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by the Apache 2.0
 // license that can be found in the LICENSE file.
 
+//go:build !appengine
 // +build !appengine
 
 package internal

--- a/internal/api_classic.go
+++ b/internal/api_classic.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by the Apache 2.0
 // license that can be found in the LICENSE file.
 
+//go:build appengine
 // +build appengine
 
 package internal

--- a/internal/api_race_test.go
+++ b/internal/api_race_test.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by the Apache 2.0
 // license that can be found in the LICENSE file.
 
+//go:build race
 // +build race
 
 package internal

--- a/internal/api_test.go
+++ b/internal/api_test.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by the Apache 2.0
 // license that can be found in the LICENSE file.
 
+//go:build !appengine
 // +build !appengine
 
 package internal

--- a/internal/identity_classic.go
+++ b/internal/identity_classic.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by the Apache 2.0
 // license that can be found in the LICENSE file.
 
+//go:build appengine
 // +build appengine
 
 package internal

--- a/internal/identity_flex.go
+++ b/internal/identity_flex.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by the Apache 2.0
 // license that can be found in the LICENSE file.
 
+//go:build appenginevm
 // +build appenginevm
 
 package internal

--- a/internal/identity_vm.go
+++ b/internal/identity_vm.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by the Apache 2.0
 // license that can be found in the LICENSE file.
 
+//go:build !appengine
 // +build !appengine
 
 package internal

--- a/internal/internal_vm_test.go
+++ b/internal/internal_vm_test.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by the Apache 2.0
 // license that can be found in the LICENSE file.
 
+//go:build !appengine
 // +build !appengine
 
 package internal

--- a/internal/main.go
+++ b/internal/main.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by the Apache 2.0
 // license that can be found in the LICENSE file.
 
+//go:build appengine
 // +build appengine
 
 package internal

--- a/internal/main_test.go
+++ b/internal/main_test.go
@@ -1,3 +1,4 @@
+//go:build !appengine
 // +build !appengine
 
 package internal

--- a/internal/main_vm.go
+++ b/internal/main_vm.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by the Apache 2.0
 // license that can be found in the LICENSE file.
 
+//go:build !appengine
 // +build !appengine
 
 package internal

--- a/internal/net_test.go
+++ b/internal/net_test.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by the Apache 2.0
 // license that can be found in the LICENSE file.
 
+//go:build !appengine
 // +build !appengine
 
 package internal

--- a/internal/user/user_service.pb.go
+++ b/internal/user/user_service.pb.go
@@ -38,7 +38,7 @@ var UserServiceError_ErrorCode_name = map[int32]string{
 	5: "OAUTH_ERROR",
 }
 var UserServiceError_ErrorCode_value = map[string]int32{
-	"OK": 0,
+	"OK":                    0,
 	"REDIRECT_URL_TOO_LONG": 1,
 	"NOT_ALLOWED":           2,
 	"OAUTH_INVALID_TOKEN":   3,

--- a/log/log.go
+++ b/log/log.go
@@ -7,6 +7,7 @@ Package log provides the means of writing and querying an application's logs
 from within an App Engine application.
 
 Example:
+
 	c := appengine.NewContext(r)
 	query := &log.Query{
 		AppLogs:  true,

--- a/mail/mail.go
+++ b/mail/mail.go
@@ -7,6 +7,7 @@ Package mail provides the means of sending email from an
 App Engine application.
 
 Example:
+
 	msg := &mail.Message{
 		Sender:  "romeo@montague.com",
 		To:      []string{"Juliet <juliet@capulet.org>"},

--- a/search/doc.go
+++ b/search/doc.go
@@ -5,8 +5,7 @@
 /*
 Package search provides a client for App Engine's search service.
 
-
-Basic Operations
+# Basic Operations
 
 Indexes contain documents. Each index is identified by its name: a
 human-readable ASCII string.
@@ -54,8 +53,7 @@ to Get to hold the resulting document.
 		return err
 	}
 
-
-Search and Listing Documents
+# Search and Listing Documents
 
 Indexes have two methods for retrieving multiple documents at once: Search and
 List.
@@ -98,8 +96,7 @@ Call List to iterate over all documents in an index.
 		fmt.Fprintf(w, "%s -> %#v\n", id, doc)
 	}
 
-
-Fields and Facets
+# Fields and Facets
 
 A document's contents can be represented by a variety of types. These are
 typically struct pointers, but they can also be represented by any type
@@ -145,8 +142,7 @@ Example code:
 		I float64 `search:",facet" json:"i"`
 	}
 
-
-The FieldLoadSaver Interface
+# The FieldLoadSaver Interface
 
 A document's contents can also be represented by any type that implements the
 FieldLoadSaver interface. This type may be a struct pointer, but it

--- a/socket/socket_classic.go
+++ b/socket/socket_classic.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by the Apache 2.0
 // license that can be found in the LICENSE file.
 
+//go:build appengine
 // +build appengine
 
 package socket

--- a/socket/socket_vm.go
+++ b/socket/socket_vm.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by the Apache 2.0
 // license that can be found in the LICENSE file.
 
+//go:build !appengine
 // +build !appengine
 
 package socket

--- a/user/user_classic.go
+++ b/user/user_classic.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by the Apache 2.0
 // license that can be found in the LICENSE file.
 
+//go:build appengine
 // +build appengine
 
 package user

--- a/user/user_test.go
+++ b/user/user_test.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by the Apache 2.0
 // license that can be found in the LICENSE file.
 
+//go:build !appengine
 // +build !appengine
 
 package user

--- a/user/user_vm.go
+++ b/user/user_vm.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by the Apache 2.0
 // license that can be found in the LICENSE file.
 
+//go:build !appengine
 // +build !appengine
 
 package user

--- a/v2/appengine.go
+++ b/v2/appengine.go
@@ -35,18 +35,18 @@ import (
 //
 // Main is designed so that the app's main package looks like this:
 //
-//      package main
+//	package main
 //
-//      import (
-//              "google.golang.org/appengine/v2"
+//	import (
+//	        "google.golang.org/appengine/v2"
 //
-//              _ "myapp/package0"
-//              _ "myapp/package1"
-//      )
+//	        _ "myapp/package0"
+//	        _ "myapp/package1"
+//	)
 //
-//      func main() {
-//              appengine.Main()
-//      }
+//	func main() {
+//	        appengine.Main()
+//	}
 //
 // The "myapp/packageX" packages are expected to register HTTP handlers
 // in their init functions.

--- a/v2/capability/capability.go
+++ b/v2/capability/capability.go
@@ -9,6 +9,7 @@ for specific API capabilities.
 This package does not work in App Engine "flexible environment".
 
 Example:
+
 	if !capability.Enabled(c, "datastore_v3", "write") {
 		// show user a different page
 	}

--- a/v2/cmd/aebundler/aebundler.go
+++ b/v2/cmd/aebundler/aebundler.go
@@ -8,9 +8,10 @@
 // A main func is synthesized if one does not exist.
 //
 // A sample Dockerfile to be used with this bundler could look like this:
-//     FROM gcr.io/google-appengine/go-compat
-//     ADD . /app
-//     RUN GOPATH=/app/_gopath go build -tags appenginevm -o /app/_ah/exe
+//
+//	FROM gcr.io/google-appengine/go-compat
+//	ADD . /app
+//	RUN GOPATH=/app/_gopath go build -tags appenginevm -o /app/_ah/exe
 package main
 
 import (

--- a/v2/datastore/doc.go
+++ b/v2/datastore/doc.go
@@ -5,8 +5,7 @@
 /*
 Package datastore provides a client for App Engine's datastore service.
 
-
-Basic Operations
+# Basic Operations
 
 Entities are the unit of storage and are associated with a key. A key
 consists of an optional parent key, a string application ID, a string kind
@@ -74,8 +73,7 @@ GetMulti, PutMulti and DeleteMulti are batch versions of the Get, Put and
 Delete functions. They take a []*Key instead of a *Key, and may return an
 appengine.MultiError when encountering partial failure.
 
-
-Properties
+# Properties
 
 An entity's contents can be represented by a variety of types. These are
 typically struct pointers, but can also be any type that implements the
@@ -137,8 +135,7 @@ Example code:
 		J int `datastore:",noindex" json:"j"`
 	}
 
-
-Structured Properties
+# Structured Properties
 
 If the struct pointed to contains other structs, then the nested or embedded
 structs are flattened. For example, given these definitions:
@@ -179,8 +176,7 @@ equivalent field would instead be: FooDotZ bool `datastore:"Foo.Z"`.
 If an outer struct is tagged "noindex" then all of its implicit flattened
 fields are effectively "noindex".
 
-
-The PropertyLoadSaver Interface
+# The PropertyLoadSaver Interface
 
 An entity's contents can also be represented by any type that implements the
 PropertyLoadSaver interface. This type may be a struct pointer, but it does
@@ -230,8 +226,7 @@ Example code:
 The *PropertyList type implements PropertyLoadSaver, and can therefore hold an
 arbitrary entity's contents.
 
-
-Queries
+# Queries
 
 Queries retrieve entities based on their properties or key's ancestry. Running
 a query yields an iterator of results: either keys or (key, entity) pairs.
@@ -284,8 +279,7 @@ Example code:
 		io.Copy(w, b)
 	}
 
-
-Transactions
+# Transactions
 
 RunInTransaction runs a function in a transaction.
 
@@ -323,8 +317,7 @@ Example code:
 		fmt.Fprintf(w, "Count=%d", count)
 	}
 
-
-Metadata
+# Metadata
 
 The datastore package provides access to some of App Engine's datastore
 metadata. This metadata includes information about the entity groups,

--- a/v2/datastore/metadata.go
+++ b/v2/datastore/metadata.go
@@ -50,13 +50,14 @@ func keyNames(keys []*Key) []string {
 // The properties are returned as a map of property names to a slice of the
 // representation types. The representation types for the supported Go property
 // types are:
-//   "INT64":     signed integers and time.Time
-//   "DOUBLE":    float32 and float64
-//   "BOOLEAN":   bool
-//   "STRING":    string, []byte and ByteString
-//   "POINT":     appengine.GeoPoint
-//   "REFERENCE": *Key
-//   "USER":      (not used in the Go runtime)
+//
+//	"INT64":     signed integers and time.Time
+//	"DOUBLE":    float32 and float64
+//	"BOOLEAN":   bool
+//	"STRING":    string, []byte and ByteString
+//	"POINT":     appengine.GeoPoint
+//	"REFERENCE": *Key
+//	"USER":      (not used in the Go runtime)
 func KindProperties(ctx context.Context, kind string) (map[string][]string, error) {
 	// TODO(djd): Support range queries.
 	kindKey := NewKey(ctx, kindKind, kind, 0, nil)

--- a/v2/datastore/query.go
+++ b/v2/datastore/query.go
@@ -476,7 +476,7 @@ func callNext(c context.Context, res *pb.QueryResult, offset, count int32) error
 // The keys returned by GetAll will be in a 1-1 correspondence with the entities
 // added to dst.
 //
-// If q is a ``keys-only'' query, GetAll ignores dst and only returns the keys.
+// If q is a “keys-only” query, GetAll ignores dst and only returns the keys.
 //
 // The running time and number of API calls made by GetAll scale linearly with
 // the sum of the query's offset and limit. Unless the result count is

--- a/v2/delay/delay.go
+++ b/v2/delay/delay.go
@@ -220,10 +220,13 @@ type invocation struct {
 }
 
 // Call invokes a delayed function.
-//   err := f.Call(c, ...)
+//
+//	err := f.Call(c, ...)
+//
 // is equivalent to
-//   t, _ := f.Task(...)
-//   _, err := taskqueue.Add(c, t, "")
+//
+//	t, _ := f.Task(...)
+//	_, err := taskqueue.Add(c, t, "")
 func (f *Function) Call(c context.Context, args ...interface{}) error {
 	t, err := f.Task(args...)
 	if err != nil {

--- a/v2/delay/delay_test.go
+++ b/v2/delay/delay_test.go
@@ -447,7 +447,6 @@ func TestInvalidFunction_MustRegister(t *testing.T) {
 	MustRegister("invalid", func() {})
 }
 
-
 func TestGetRequestHeadersFromContext(t *testing.T) {
 	for _, testTarget := range []*Function{requestFunc, requestRegister} {
 		c := newFakeContext()

--- a/v2/internal/api_race_test.go
+++ b/v2/internal/api_race_test.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by the Apache 2.0
 // license that can be found in the LICENSE file.
 
+//go:build race
 // +build race
 
 package internal

--- a/v2/internal/identity_flex.go
+++ b/v2/internal/identity_flex.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by the Apache 2.0
 // license that can be found in the LICENSE file.
 
+//go:build appenginevm
 // +build appenginevm
 
 package internal

--- a/v2/mail/mail.go
+++ b/v2/mail/mail.go
@@ -7,6 +7,7 @@ Package mail provides the means of sending email from an
 App Engine application.
 
 Example:
+
 	msg := &mail.Message{
 		Sender:  "romeo@montague.com",
 		To:      []string{"Juliet <juliet@capulet.org>"},

--- a/xmpp/xmpp.go
+++ b/xmpp/xmpp.go
@@ -7,6 +7,7 @@ Package xmpp provides the means to send and receive instant messages
 to and from users of XMPP-compatible services.
 
 To send a message,
+
 	m := &xmpp.Message{
 		To:   []string{"kaylee@example.com"},
 		Body: `Hi! How's the carrot?`,
@@ -14,6 +15,7 @@ To send a message,
 	err := m.Send(c)
 
 To receive messages,
+
 	func init() {
 		xmpp.Handle(handleChat)
 	}


### PR DESCRIPTION
See https://github.com/golang/proposal/blob/master/design/51082-godocfmt.md#reformatting-doc-comments for why gofmt suddenly cares much more about comments than it used to.

This also updates some old go<=1.16 style build tags to use the go1.17+ "go:build" style.