### PR TITLE
respect GAE_ENV=localdev

### DIFF
--- a/internal/identity_vm.go
+++ b/internal/identity_vm.go
@@ -131,5 +131,5 @@ func fullyQualifiedAppID(_ netcontext.Context) string {
 }
 
 func IsDevAppServer() bool {
-	return os.Getenv("RUN_WITH_DEVAPPSERVER") != ""
+	return os.Getenv("RUN_WITH_DEVAPPSERVER") != "" || os.Getenv("GAE_ENV") == "localdev"
 }

--- a/v2/internal/identity.go
+++ b/v2/internal/identity.go
@@ -167,5 +167,5 @@ func fullyQualifiedAppID(_ netcontext.Context) string {
 }
 
 func IsDevAppServer() bool {
-	return os.Getenv("RUN_WITH_DEVAPPSERVER") != ""
+	return os.Getenv("RUN_WITH_DEVAPPSERVER") != "" || os.Getenv("GAE_ENV") == "localdev"
 }

--- a/v2/internal/identity_test.go
+++ b/v2/internal/identity_test.go
@@ -1,0 +1,47 @@
+package internal
+
+import (
+	"os"
+	"testing"
+)
+
+func TestIsDevAppServer(t *testing.T) {
+	tests := []struct {
+		desc string // See http://go/gotip/episodes/25 for naming guidance.
+		env  map[string]string
+		want bool
+	}{
+		{desc: "empty", env: map[string]string{}, want: false},
+		{desc: "legacy", env: map[string]string{"RUN_WITH_DEVAPPSERVER": "1"}, want: true},
+		{desc: "new", env: map[string]string{"GAE_ENV": "localdev"}, want: true},
+	}
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			for key, value := range test.env {
+				defer setenv(t, key, value)()
+			}
+			if got := IsDevAppServer(); got != test.want {
+				t.Errorf("env=%v IsDevAppServer() got %v, want %v", test.env, got, test.want)
+			}
+		})
+	}
+}
+
+// setenv is a backport of https://pkg.go.dev/testing#T.Setenv
+func setenv(t *testing.T, key, value string) func() {
+	t.Helper()
+	prevValue, ok := os.LookupEnv(key)
+
+	if err := os.Setenv(key, value); err != nil {
+		t.Fatalf("cannot set environment variable: %v", err)
+	}
+
+	if ok {
+		return func() {
+			os.Setenv(key, prevValue)
+		}
+	}
+	return func() {
+		os.Unsetenv(key)
+	}
+}


### PR DESCRIPTION
The public docs at https://cloud.google.com/appengine/docs/standard/go/testing-and-deploying-your-app#detecting_application_runtime_environment tell you that GAE_ENV is the value to switch on to determine if you're running in devappserver or not.  `appengine.IsDevAppserver()` should obviously use the same variable that we encourage users to check directly.