### PR TITLE
just a small refactor of api_test

### DIFF
--- a/v2/internal/api.go
+++ b/v2/internal/api.go
@@ -248,9 +248,8 @@ func WithContext(parent netcontext.Context, req *http.Request) netcontext.Contex
 }
 
 // RegisterTestRequest registers the HTTP request req for testing, such that
-// any API calls are sent to the provided URL. It returns a closure to delete
-// the registration.
-// It should only be used by aetest package.
+// any API calls are sent to the provided URL.
+// It should only be used by test code or test helpers like aetest.
 func RegisterTestRequest(req *http.Request, apiURL *url.URL, appID string) *http.Request {
 	ctx := req.Context()
 	ctx = withAPIHostOverride(ctx, apiURL.Hostname())

--- a/v2/internal/net_test.go
+++ b/v2/internal/net_test.go
@@ -26,7 +26,7 @@ func TestDialLimit(t *testing.T) {
 		}
 	}()
 
-	f, c, cleanup := setup() // setup is in api_test.go
+	f, r, cleanup := setup() // setup is in api_test.go
 	defer cleanup()
 	f.hang = make(chan int)
 
@@ -37,12 +37,12 @@ func TestDialLimit(t *testing.T) {
 	for i := 0; i < 2; i++ {
 		go func() {
 			defer wg.Done()
-			Call(toContext(c), "errors", "RunSlowly", &basepb.VoidProto{}, &basepb.VoidProto{})
+			Call(r.Context(), "errors", "RunSlowly", &basepb.VoidProto{}, &basepb.VoidProto{})
 		}()
 	}
 	time.Sleep(50 * time.Millisecond) // let those two RPCs start
 
-	ctx, _ := netcontext.WithTimeout(toContext(c), 50*time.Millisecond)
+	ctx, _ := netcontext.WithTimeout(r.Context(), 50*time.Millisecond)
 	err := Call(ctx, "errors", "Non200", &basepb.VoidProto{}, &basepb.VoidProto{})
 	if err != errTimeout {
 		t.Errorf("Non200 RPC returned with err %v, want errTimeout", err)


### PR DESCRIPTION
This makes the test more hermetic by avoiding the need to set env vars, and it also avoids some unecessary duplication of test helper logic by leveraging some of aetest's underlying implementation (namely RegisterTestRequest).

This change was originally part of #284, but I split it out because it's not compatible with v1's log flushing tests, and it would have added unecessary noise to that PR.