### PR TITLE
all: using the more elegant way to deal milliseconds and nanoseconds

### DIFF
--- a/internal/api.go
+++ b/internal/api.go
@@ -551,7 +551,7 @@ func logf(c *context, level int64, format string, args ...interface{}) {
 	s = strings.TrimRight(s, "\n") // Remove any trailing newline characters.
 	if logToLogservice() {
 		c.addLogLine(&logpb.UserAppLogLine{
-			TimestampUsec: proto.Int64(time.Now().UnixNano() / 1e3),
+			TimestampUsec: proto.Int64(time.Now().UnixMicro()),
 			Level:         &level,
 			Message:       &s,
 		})

--- a/log/log.go
+++ b/log/log.go
@@ -245,10 +245,10 @@ func makeRequest(params *Query, appID, versionID string) (*pb.LogReadRequest, er
 	req := &pb.LogReadRequest{}
 	req.AppId = &appID
 	if !params.StartTime.IsZero() {
-		req.StartTime = proto.Int64(params.StartTime.UnixNano() / 1e3)
+		req.StartTime = proto.Int64(params.StartTime.UnixMicro())
 	}
 	if !params.EndTime.IsZero() {
-		req.EndTime = proto.Int64(params.EndTime.UnixNano() / 1e3)
+		req.EndTime = proto.Int64(params.EndTime.UnixMicro())
 	}
 	if len(params.Offset) > 0 {
 		var offset pb.LogOffset

--- a/search/search.go
+++ b/search/search.go
@@ -977,7 +977,7 @@ func fieldsToProto(src []Field) ([]*pb.Field, error) {
 			}
 			timeFields[f.Name] = true
 			fieldValue.Type = pb.FieldValue_DATE.Enum()
-			fieldValue.StringValue = proto.String(strconv.FormatInt(x.UnixNano()/1e6, 10))
+			fieldValue.StringValue = proto.String(strconv.FormatInt(x.UnixMilli(), 10))
 		case float64:
 			if numericFields[f.Name] {
 				return nil, fmt.Errorf("search: duplicate numeric field %q", f.Name)

--- a/taskqueue/taskqueue.go
+++ b/taskqueue/taskqueue.go
@@ -216,7 +216,7 @@ func newAddReq(c context.Context, task *Task, queueName string) (*pb.TaskQueueAd
 	req := &pb.TaskQueueAddRequest{
 		QueueName: []byte(queueName),
 		TaskName:  []byte(task.Name),
-		EtaUsec:   proto.Int64(eta.UnixNano() / 1e3),
+		EtaUsec:   proto.Int64(eta.UnixMicro()),
 	}
 	method := task.method()
 	if method == "PULL" {
@@ -467,7 +467,7 @@ func ModifyLease(c context.Context, task *Task, queueName string, leaseTime int)
 	req := &pb.TaskQueueModifyTaskLeaseRequest{
 		QueueName:    []byte(queueName),
 		TaskName:     []byte(task.Name),
-		EtaUsec:      proto.Int64(task.ETA.UnixNano() / 1e3), // Used to verify ownership.
+		EtaUsec:      proto.Int64(task.ETA.UnixMicro()), // Used to verify ownership.
 		LeaseSeconds: proto.Float64(float64(leaseTime)),
 	}
 	res := &pb.TaskQueueModifyTaskLeaseResponse{}

--- a/v2/taskqueue/taskqueue.go
+++ b/v2/taskqueue/taskqueue.go
@@ -216,7 +216,7 @@ func newAddReq(c context.Context, task *Task, queueName string) (*pb.TaskQueueAd
 	req := &pb.TaskQueueAddRequest{
 		QueueName: []byte(queueName),
 		TaskName:  []byte(task.Name),
-		EtaUsec:   proto.Int64(eta.UnixNano() / 1e3),
+		EtaUsec:   proto.Int64(eta.UnixMicro()),
 	}
 	method := task.method()
 	if method == "PULL" {
@@ -467,7 +467,7 @@ func ModifyLease(c context.Context, task *Task, queueName string, leaseTime int)
 	req := &pb.TaskQueueModifyTaskLeaseRequest{
 		QueueName:    []byte(queueName),
 		TaskName:     []byte(task.Name),
-		EtaUsec:      proto.Int64(task.ETA.UnixNano() / 1e3), // Used to verify ownership.
+		EtaUsec:      proto.Int64(task.ETA.UnixMicro()), // Used to verify ownership.
 		LeaseSeconds: proto.Float64(float64(leaseTime)),
 	}
 	res := &pb.TaskQueueModifyTaskLeaseResponse{}


### PR DESCRIPTION
Go 1.17 added support for milliseconds and microseconds, using them can make the code more concise and readable