### PR TITLE
remove golang.org/x/net dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ code importing `appengine/datastore` will now need to import `google.golang.org/
 Most App Engine services are available with exactly the same API.
 A few APIs were cleaned up, and there are some differences:
 
-* `appengine.Context` has been replaced with the `Context` type from `golang.org/x/net/context`.
+* `appengine.Context` has been replaced with the `Context` type from `context`.
 * Logging methods that were on `appengine.Context` are now functions in `google.golang.org/appengine/log`.
 * `appengine.Timeout` has been removed. Use `context.WithTimeout` instead.
 * `appengine.Datacenter` now takes a `context.Context` argument.

--- a/aetest/instance.go
+++ b/aetest/instance.go
@@ -1,11 +1,11 @@
 package aetest
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"time"
 
-	"golang.org/x/net/context"
 	"google.golang.org/appengine"
 )
 

--- a/appengine.go
+++ b/appengine.go
@@ -9,10 +9,10 @@
 package appengine // import "google.golang.org/appengine"
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/golang/protobuf/proto"
-	"golang.org/x/net/context"
 
 	"google.golang.org/appengine/internal"
 )

--- a/blobstore/blobstore.go
+++ b/blobstore/blobstore.go
@@ -9,6 +9,7 @@ package blobstore // import "google.golang.org/appengine/blobstore"
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"encoding/base64"
 	"fmt"
 	"io"
@@ -23,7 +24,6 @@ import (
 	"time"
 
 	"github.com/golang/protobuf/proto"
-	"golang.org/x/net/context"
 	"golang.org/x/text/encoding/htmlindex"
 
 	"google.golang.org/appengine"

--- a/blobstore/read.go
+++ b/blobstore/read.go
@@ -5,6 +5,7 @@
 package blobstore
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -12,7 +13,6 @@ import (
 	"sync"
 
 	"github.com/golang/protobuf/proto"
-	"golang.org/x/net/context"
 
 	"google.golang.org/appengine"
 	"google.golang.org/appengine/internal"

--- a/capability/capability.go
+++ b/capability/capability.go
@@ -17,7 +17,7 @@ Example:
 package capability // import "google.golang.org/appengine/capability"
 
 import (
-	"golang.org/x/net/context"
+	"context"
 
 	"google.golang.org/appengine/internal"
 	"google.golang.org/appengine/log"

--- a/channel/channel.go
+++ b/channel/channel.go
@@ -25,9 +25,8 @@ https://cloud.google.com/appengine/docs/deprecations/channel
 package channel // import "google.golang.org/appengine/channel"
 
 import (
+	"context"
 	"encoding/json"
-
-	"golang.org/x/net/context"
 
 	"google.golang.org/appengine"
 	"google.golang.org/appengine/internal"

--- a/cmd/aefix/ae.go
+++ b/cmd/aefix/ae.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	ctxPackage = "golang.org/x/net/context"
+	ctxPackage = "context"
 
 	newPackageBase = "google.golang.org/"
 	stutterPackage = false

--- a/cmd/aefix/ae_test.go
+++ b/cmd/aefix/ae_test.go
@@ -38,10 +38,10 @@ func f(w http.ResponseWriter, r *http.Request) {
 		Out: `package foo
 
 import (
+	"context"
 	"net/http"
 	"time"
 
-	"golang.org/x/net/context"
 	"google.golang.org/appengine"
 	"google.golang.org/appengine/datastore"
 	"google.golang.org/appengine/log"
@@ -74,7 +74,7 @@ func LogSomething(c2 appengine.Context) {
 		Out: `package foo
 
 import (
-	"golang.org/x/net/context"
+	"context"
 	"google.golang.org/appengine/log"
 )
 
@@ -102,7 +102,7 @@ func f(ctx appengine.Context) {
 		Out: `package foo
 
 import (
-	"golang.org/x/net/context"
+	"context"
 	"google.golang.org/appengine/taskqueue"
 )
 
@@ -131,7 +131,7 @@ func f(ctx appengine.Context, w io.Writer) {
 		Out: `package foo
 
 import (
-	"golang.org/x/net/context"
+	"context"
 	"google.golang.org/appengine"
 	"io"
 )

--- a/datastore/datastore.go
+++ b/datastore/datastore.go
@@ -5,12 +5,12 @@
 package datastore
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"reflect"
 
 	"github.com/golang/protobuf/proto"
-	"golang.org/x/net/context"
 
 	"google.golang.org/appengine"
 	"google.golang.org/appengine/internal"

--- a/datastore/key.go
+++ b/datastore/key.go
@@ -6,6 +6,7 @@ package datastore
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"encoding/gob"
 	"errors"
@@ -14,7 +15,6 @@ import (
 	"strings"
 
 	"github.com/golang/protobuf/proto"
-	"golang.org/x/net/context"
 
 	"google.golang.org/appengine/internal"
 	pb "google.golang.org/appengine/internal/datastore"

--- a/datastore/key_test.go
+++ b/datastore/key_test.go
@@ -6,11 +6,10 @@ package datastore
 
 import (
 	"bytes"
+	"context"
 	"encoding/gob"
 	"encoding/json"
 	"testing"
-
-	"golang.org/x/net/context"
 
 	"google.golang.org/appengine/internal"
 )

--- a/datastore/keycompat.go
+++ b/datastore/keycompat.go
@@ -5,9 +5,8 @@
 package datastore
 
 import (
+	"context"
 	"sync"
-
-	"golang.org/x/net/context"
 
 	"google.golang.org/appengine/datastore/internal/cloudkey"
 	"google.golang.org/appengine/internal"

--- a/datastore/metadata.go
+++ b/datastore/metadata.go
@@ -4,7 +4,7 @@
 
 package datastore
 
-import "golang.org/x/net/context"
+import "context"
 
 // Datastore kinds for the metadata entities.
 const (

--- a/datastore/query.go
+++ b/datastore/query.go
@@ -5,6 +5,7 @@
 package datastore
 
 import (
+	"context"
 	"encoding/base64"
 	"errors"
 	"fmt"
@@ -13,7 +14,6 @@ import (
 	"strings"
 
 	"github.com/golang/protobuf/proto"
-	"golang.org/x/net/context"
 
 	"google.golang.org/appengine/internal"
 	pb "google.golang.org/appengine/internal/datastore"

--- a/datastore/transaction.go
+++ b/datastore/transaction.go
@@ -5,9 +5,8 @@
 package datastore
 
 import (
+	"context"
 	"errors"
-
-	"golang.org/x/net/context"
 
 	"google.golang.org/appengine/internal"
 	pb "google.golang.org/appengine/internal/datastore"

--- a/delay/delay.go
+++ b/delay/delay.go
@@ -59,7 +59,7 @@ package delay // import "google.golang.org/appengine/delay"
 
 import (
 	"bytes"
-	stdctx "context"
+	"context"
 	"encoding/gob"
 	"errors"
 	"fmt"
@@ -71,8 +71,6 @@ import (
 	"regexp"
 	"runtime"
 	"strings"
-
-	"golang.org/x/net/context"
 
 	"google.golang.org/appengine"
 	"google.golang.org/appengine/internal"
@@ -109,12 +107,11 @@ var (
 
 	// context keys
 	headersContextKey contextKey = 0
-	stdContextType               = reflect.TypeOf((*stdctx.Context)(nil)).Elem()
-	netContextType               = reflect.TypeOf((*context.Context)(nil)).Elem()
+	stdContextType               = reflect.TypeOf((*context.Context)(nil)).Elem()
 )
 
 func isContext(t reflect.Type) bool {
-	return t == stdContextType || t == netContextType
+	return t == stdContextType
 }
 
 var modVersionPat = regexp.MustCompile("@v[^/]+")

--- a/delay/delay_test.go
+++ b/delay/delay_test.go
@@ -6,7 +6,7 @@ package delay
 
 import (
 	"bytes"
-	stdctx "context"
+	"context"
 	"encoding/gob"
 	"errors"
 	"fmt"
@@ -18,7 +18,6 @@ import (
 	"testing"
 
 	"github.com/golang/protobuf/proto"
-	"golang.org/x/net/context"
 
 	"google.golang.org/appengine/internal"
 	"google.golang.org/appengine/taskqueue"
@@ -107,7 +106,7 @@ var (
 	})
 
 	stdCtxRuns = 0
-	stdCtxFunc = Func("stdctx", func(c stdctx.Context) {
+	stdCtxFunc = Func("stdctx", func(c context.Context) {
 		stdCtxRuns++
 	})
 )

--- a/demos/guestbook/guestbook.go
+++ b/demos/guestbook/guestbook.go
@@ -9,11 +9,10 @@
 package main
 
 import (
+	"context"
 	"html/template"
 	"net/http"
 	"time"
-
-	"golang.org/x/net/context"
 
 	"google.golang.org/appengine"
 	"google.golang.org/appengine/datastore"

--- a/file/file.go
+++ b/file/file.go
@@ -6,9 +6,8 @@
 package file
 
 import (
+	"context"
 	"fmt"
-
-	"golang.org/x/net/context"
 
 	"google.golang.org/appengine/internal"
 	aipb "google.golang.org/appengine/internal/app_identity"

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,5 @@ go 1.11
 
 require (
 	github.com/golang/protobuf v1.5.2
-	golang.org/x/net v0.0.0-20210525063256-abc453219eb5
 	golang.org/x/text v0.3.6
 )

--- a/go.sum
+++ b/go.sum
@@ -3,11 +3,6 @@ github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-golang.org/x/net v0.0.0-20210525063256-abc453219eb5 h1:wjuX4b5yYQnEQHzd+CBcrcC6OVR2J1CN6mUy0oSxIPo=
-golang.org/x/net v0.0.0-20210525063256-abc453219eb5/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.6 h1:aRYxNxv6iGQlyVaZmk6ZgYEDa+Jg18DxebPSrd6bg1M=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/identity.go
+++ b/identity.go
@@ -5,9 +5,8 @@
 package appengine
 
 import (
+	"context"
 	"time"
-
-	"golang.org/x/net/context"
 
 	"google.golang.org/appengine/internal"
 	pb "google.golang.org/appengine/internal/app_identity"

--- a/image/image.go
+++ b/image/image.go
@@ -6,10 +6,9 @@
 package image // import "google.golang.org/appengine/image"
 
 import (
+	"context"
 	"fmt"
 	"net/url"
-
-	"golang.org/x/net/context"
 
 	"google.golang.org/appengine"
 	"google.golang.org/appengine/internal"

--- a/internal/aetesting/fake.go
+++ b/internal/aetesting/fake.go
@@ -7,13 +7,13 @@
 package aetesting
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"reflect"
 	"testing"
 
 	"github.com/golang/protobuf/proto"
-	"golang.org/x/net/context"
 
 	"google.golang.org/appengine/internal"
 )

--- a/internal/api.go
+++ b/internal/api.go
@@ -9,6 +9,7 @@ package internal
 
 import (
 	"bytes"
+	stdctx "context"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -23,8 +24,6 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
-
-	netcontext "context"
 
 	"github.com/golang/protobuf/proto"
 
@@ -68,7 +67,7 @@ var (
 	}
 )
 
-func apiURL(ctx netcontext.Context) *url.URL {
+func apiURL(ctx stdctx.Context) *url.URL {
 	host, port := "appengine.googleapis.internal", "10001"
 	if h := os.Getenv("API_HOST"); h != "" {
 		host = h
@@ -242,8 +241,8 @@ var contextKey = "holds a *context"
 // jointContext joins two contexts in a superficial way.
 // It takes values and timeouts from a base context, and only values from another context.
 type jointContext struct {
-	base       netcontext.Context
-	valuesOnly netcontext.Context
+	base       stdctx.Context
+	valuesOnly stdctx.Context
 }
 
 func (c jointContext) Deadline() (time.Time, bool) {
@@ -267,35 +266,35 @@ func (c jointContext) Value(key interface{}) interface{} {
 
 // fromContext returns the App Engine context or nil if ctx is not
 // derived from an App Engine context.
-func fromContext(ctx netcontext.Context) *context {
+func fromContext(ctx stdctx.Context) *context {
 	c, _ := ctx.Value(&contextKey).(*context)
 	return c
 }
 
-func withContext(parent netcontext.Context, c *context) netcontext.Context {
-	ctx := netcontext.WithValue(parent, &contextKey, c)
+func withContext(parent stdctx.Context, c *context) stdctx.Context {
+	ctx := stdctx.WithValue(parent, &contextKey, c)
 	if ns := c.req.Header.Get(curNamespaceHeader); ns != "" {
 		ctx = withNamespace(ctx, ns)
 	}
 	return ctx
 }
 
-func toContext(c *context) netcontext.Context {
-	return withContext(netcontext.Background(), c)
+func toContext(c *context) stdctx.Context {
+	return withContext(stdctx.Background(), c)
 }
 
-func IncomingHeaders(ctx netcontext.Context) http.Header {
+func IncomingHeaders(ctx stdctx.Context) http.Header {
 	if c := fromContext(ctx); c != nil {
 		return c.req.Header
 	}
 	return nil
 }
 
-func ReqContext(req *http.Request) netcontext.Context {
+func ReqContext(req *http.Request) stdctx.Context {
 	return req.Context()
 }
 
-func WithContext(parent netcontext.Context, req *http.Request) netcontext.Context {
+func WithContext(parent stdctx.Context, req *http.Request) stdctx.Context {
 	return jointContext{
 		base:       parent,
 		valuesOnly: req.Context(),
@@ -359,7 +358,7 @@ func (c *context) WriteHeader(code int) {
 	c.outCode = code
 }
 
-func post(ctx netcontext.Context, body []byte, timeout time.Duration) (b []byte, err error) {
+func post(ctx stdctx.Context, body []byte, timeout time.Duration) (b []byte, err error) {
 	apiURL := apiURL(ctx)
 	hreq := &http.Request{
 		Method: "POST",
@@ -423,7 +422,7 @@ func post(ctx netcontext.Context, body []byte, timeout time.Duration) (b []byte,
 	return hrespBody, nil
 }
 
-func Call(ctx netcontext.Context, service, method string, in, out proto.Message) error {
+func Call(ctx stdctx.Context, service, method string, in, out proto.Message) error {
 	if ns := NamespaceFromContext(ctx); ns != "" {
 		if fn, ok := NamespaceMods[service]; ok {
 			fn(in, ns)
@@ -643,7 +642,7 @@ func (c *context) logFlusher(stop <-chan int) {
 	}
 }
 
-func ContextForTesting(req *http.Request) netcontext.Context {
+func ContextForTesting(req *http.Request) stdctx.Context {
 	return toContext(&context{req: req})
 }
 

--- a/internal/api.go
+++ b/internal/api.go
@@ -9,7 +9,7 @@ package internal
 
 import (
 	"bytes"
-	stdctx "context"
+	"context"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -67,7 +67,7 @@ var (
 	}
 )
 
-func apiURL(ctx stdctx.Context) *url.URL {
+func apiURL(ctx context.Context) *url.URL {
 	host, port := "appengine.googleapis.internal", "10001"
 	if h := os.Getenv("API_HOST"); h != "" {
 		host = h
@@ -95,7 +95,7 @@ func Middleware(next http.Handler) http.Handler {
 
 func handleHTTPMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		c := &context{
+		c := &aeContext{
 			req:       r,
 			outHeader: w.Header(),
 		}
@@ -171,7 +171,7 @@ func executeRequestSafelyMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		defer func() {
 			if x := recover(); x != nil {
-				c := w.(*context)
+				c := w.(*aeContext)
 				logf(c, 4, "%s", renderPanic(x)) // 4 == critical
 				c.outCode = 500
 			}
@@ -220,9 +220,9 @@ func renderPanic(x interface{}) string {
 	return string(buf)
 }
 
-// context represents the context of an in-flight HTTP request.
+// aeContext represents the aeContext of an in-flight HTTP request.
 // It implements the appengine.Context and http.ResponseWriter interfaces.
-type context struct {
+type aeContext struct {
 	req *http.Request
 
 	outCode   int
@@ -241,8 +241,8 @@ var contextKey = "holds a *context"
 // jointContext joins two contexts in a superficial way.
 // It takes values and timeouts from a base context, and only values from another context.
 type jointContext struct {
-	base       stdctx.Context
-	valuesOnly stdctx.Context
+	base       context.Context
+	valuesOnly context.Context
 }
 
 func (c jointContext) Deadline() (time.Time, bool) {
@@ -266,35 +266,35 @@ func (c jointContext) Value(key interface{}) interface{} {
 
 // fromContext returns the App Engine context or nil if ctx is not
 // derived from an App Engine context.
-func fromContext(ctx stdctx.Context) *context {
-	c, _ := ctx.Value(&contextKey).(*context)
+func fromContext(ctx context.Context) *aeContext {
+	c, _ := ctx.Value(&contextKey).(*aeContext)
 	return c
 }
 
-func withContext(parent stdctx.Context, c *context) stdctx.Context {
-	ctx := stdctx.WithValue(parent, &contextKey, c)
+func withContext(parent context.Context, c *aeContext) context.Context {
+	ctx := context.WithValue(parent, &contextKey, c)
 	if ns := c.req.Header.Get(curNamespaceHeader); ns != "" {
 		ctx = withNamespace(ctx, ns)
 	}
 	return ctx
 }
 
-func toContext(c *context) stdctx.Context {
-	return withContext(stdctx.Background(), c)
+func toContext(c *aeContext) context.Context {
+	return withContext(context.Background(), c)
 }
 
-func IncomingHeaders(ctx stdctx.Context) http.Header {
+func IncomingHeaders(ctx context.Context) http.Header {
 	if c := fromContext(ctx); c != nil {
 		return c.req.Header
 	}
 	return nil
 }
 
-func ReqContext(req *http.Request) stdctx.Context {
+func ReqContext(req *http.Request) context.Context {
 	return req.Context()
 }
 
-func WithContext(parent stdctx.Context, req *http.Request) stdctx.Context {
+func WithContext(parent context.Context, req *http.Request) context.Context {
 	return jointContext{
 		base:       parent,
 		valuesOnly: req.Context(),
@@ -311,7 +311,7 @@ func RegisterTestRequest(req *http.Request, apiURL *url.URL, appID string) *http
 	ctx = WithAppIDOverride(ctx, appID)
 
 	// use the unregistered request as a placeholder so that withContext can read the headers
-	c := &context{req: req}
+	c := &aeContext{req: req}
 	c.req = req.WithContext(withContext(ctx, c))
 	return c.req
 }
@@ -322,7 +322,7 @@ var errTimeout = &CallError{
 	Timeout: true,
 }
 
-func (c *context) Header() http.Header { return c.outHeader }
+func (c *aeContext) Header() http.Header { return c.outHeader }
 
 // Copied from $GOROOT/src/pkg/net/http/transfer.go. Some response status
 // codes do not permit a response body (nor response entity headers such as
@@ -339,7 +339,7 @@ func bodyAllowedForStatus(status int) bool {
 	return true
 }
 
-func (c *context) Write(b []byte) (int, error) {
+func (c *aeContext) Write(b []byte) (int, error) {
 	if c.outCode == 0 {
 		c.WriteHeader(http.StatusOK)
 	}
@@ -350,7 +350,7 @@ func (c *context) Write(b []byte) (int, error) {
 	return len(b), nil
 }
 
-func (c *context) WriteHeader(code int) {
+func (c *aeContext) WriteHeader(code int) {
 	if c.outCode != 0 {
 		logf(c, 3, "WriteHeader called multiple times on request.") // error level
 		return
@@ -358,7 +358,7 @@ func (c *context) WriteHeader(code int) {
 	c.outCode = code
 }
 
-func post(ctx stdctx.Context, body []byte, timeout time.Duration) (b []byte, err error) {
+func post(ctx context.Context, body []byte, timeout time.Duration) (b []byte, err error) {
 	apiURL := apiURL(ctx)
 	hreq := &http.Request{
 		Method: "POST",
@@ -422,7 +422,7 @@ func post(ctx stdctx.Context, body []byte, timeout time.Duration) (b []byte, err
 	return hrespBody, nil
 }
 
-func Call(ctx stdctx.Context, service, method string, in, out proto.Message) error {
+func Call(ctx context.Context, service, method string, in, out proto.Message) error {
 	if ns := NamespaceFromContext(ctx); ns != "" {
 		if fn, ok := NamespaceMods[service]; ok {
 			fn(in, ns)
@@ -445,7 +445,7 @@ func Call(ctx stdctx.Context, service, method string, in, out proto.Message) err
 	// Apply transaction modifications if we're in a transaction.
 	if t := transactionFromContext(ctx); t != nil {
 		if t.finished {
-			return errors.New("transaction context has expired")
+			return errors.New("transaction aeContext has expired")
 		}
 		applyTransaction(in, &t.transaction)
 	}
@@ -516,11 +516,11 @@ func Call(ctx stdctx.Context, service, method string, in, out proto.Message) err
 	return proto.Unmarshal(res.Response, out)
 }
 
-func (c *context) Request() *http.Request {
+func (c *aeContext) Request() *http.Request {
 	return c.req
 }
 
-func (c *context) addLogLine(ll *logpb.UserAppLogLine) {
+func (c *aeContext) addLogLine(ll *logpb.UserAppLogLine) {
 	// Truncate long log lines.
 	// TODO(dsymonds): Check if this is still necessary.
 	const lim = 8 << 10
@@ -542,9 +542,9 @@ var logLevelName = map[int64]string{
 	4: "CRITICAL",
 }
 
-func logf(c *context, level int64, format string, args ...interface{}) {
+func logf(c *aeContext, level int64, format string, args ...interface{}) {
 	if c == nil {
-		panic("not an App Engine context")
+		panic("not an App Engine aeContext")
 	}
 	s := fmt.Sprintf(format, args...)
 	s = strings.TrimRight(s, "\n") // Remove any trailing newline characters.
@@ -563,7 +563,7 @@ func logf(c *context, level int64, format string, args ...interface{}) {
 
 // flushLog attempts to flush any pending logs to the appserver.
 // It should not be called concurrently.
-func (c *context) flushLog(force bool) (flushed bool) {
+func (c *aeContext) flushLog(force bool) (flushed bool) {
 	c.pendingLogs.Lock()
 	// Grab up to 30 MB. We can get away with up to 32 MB, but let's be cautious.
 	n, rem := 0, 30<<20
@@ -624,7 +624,7 @@ const (
 	forceFlushInterval = 60 * time.Second
 )
 
-func (c *context) logFlusher(stop <-chan int) {
+func (c *aeContext) logFlusher(stop <-chan int) {
 	lastFlush := time.Now()
 	tick := time.NewTicker(flushInterval)
 	for {
@@ -642,8 +642,8 @@ func (c *context) logFlusher(stop <-chan int) {
 	}
 }
 
-func ContextForTesting(req *http.Request) stdctx.Context {
-	return toContext(&context{req: req})
+func ContextForTesting(req *http.Request) context.Context {
+	return toContext(&aeContext{req: req})
 }
 
 func logToLogservice() bool {

--- a/internal/api_classic.go
+++ b/internal/api_classic.go
@@ -8,7 +8,7 @@
 package internal
 
 import (
-	stdctx "context"
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -25,13 +25,13 @@ var contextKey = "holds an appengine.Context"
 
 // fromContext returns the App Engine context or nil if ctx is not
 // derived from an App Engine context.
-func fromContext(ctx stdctx.Context) appengine.Context {
+func fromContext(ctx context.Context) appengine.Context {
 	c, _ := ctx.Value(&contextKey).(appengine.Context)
 	return c
 }
 
 // This is only for classic App Engine adapters.
-func ClassicContextFromContext(ctx stdctx.Context) (appengine.Context, error) {
+func ClassicContextFromContext(ctx context.Context) (appengine.Context, error) {
 	c := fromContext(ctx)
 	if c == nil {
 		return nil, errNotAppEngineContext
@@ -39,8 +39,8 @@ func ClassicContextFromContext(ctx stdctx.Context) (appengine.Context, error) {
 	return c, nil
 }
 
-func withContext(parent stdctx.Context, c appengine.Context) stdctx.Context {
-	ctx := stdctx.WithValue(parent, &contextKey, c)
+func withContext(parent context.Context, c appengine.Context) context.Context {
+	ctx := context.WithValue(parent, &contextKey, c)
 
 	s := &basepb.StringProto{}
 	c.Call("__go__", "GetNamespace", &basepb.VoidProto{}, s, nil)
@@ -51,7 +51,7 @@ func withContext(parent stdctx.Context, c appengine.Context) stdctx.Context {
 	return ctx
 }
 
-func IncomingHeaders(ctx stdctx.Context) http.Header {
+func IncomingHeaders(ctx context.Context) http.Header {
 	if c := fromContext(ctx); c != nil {
 		if req, ok := c.Request().(*http.Request); ok {
 			return req.Header
@@ -60,11 +60,11 @@ func IncomingHeaders(ctx stdctx.Context) http.Header {
 	return nil
 }
 
-func ReqContext(req *http.Request) stdctx.Context {
-	return WithContext(stdctx.Background(), req)
+func ReqContext(req *http.Request) context.Context {
+	return WithContext(context.Background(), req)
 }
 
-func WithContext(parent stdctx.Context, req *http.Request) stdctx.Context {
+func WithContext(parent context.Context, req *http.Request) context.Context {
 	c := appengine.NewContext(req)
 	return withContext(parent, c)
 }
@@ -84,11 +84,11 @@ func (t *testingContext) Call(service, method string, _, _ appengine_internal.Pr
 }
 func (t *testingContext) Request() interface{} { return t.req }
 
-func ContextForTesting(req *http.Request) stdctx.Context {
-	return withContext(stdctx.Background(), &testingContext{req: req})
+func ContextForTesting(req *http.Request) context.Context {
+	return withContext(context.Background(), &testingContext{req: req})
 }
 
-func Call(ctx stdctx.Context, service, method string, in, out proto.Message) error {
+func Call(ctx context.Context, service, method string, in, out proto.Message) error {
 	if ns := NamespaceFromContext(ctx); ns != "" {
 		if fn, ok := NamespaceMods[service]; ok {
 			fn(in, ns)

--- a/internal/api_classic.go
+++ b/internal/api_classic.go
@@ -8,6 +8,7 @@
 package internal
 
 import (
+	stdctx "context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -18,20 +19,19 @@ import (
 	basepb "appengine_internal/base"
 
 	"github.com/golang/protobuf/proto"
-	netcontext "golang.org/x/net/context"
 )
 
 var contextKey = "holds an appengine.Context"
 
 // fromContext returns the App Engine context or nil if ctx is not
 // derived from an App Engine context.
-func fromContext(ctx netcontext.Context) appengine.Context {
+func fromContext(ctx stdctx.Context) appengine.Context {
 	c, _ := ctx.Value(&contextKey).(appengine.Context)
 	return c
 }
 
 // This is only for classic App Engine adapters.
-func ClassicContextFromContext(ctx netcontext.Context) (appengine.Context, error) {
+func ClassicContextFromContext(ctx stdctx.Context) (appengine.Context, error) {
 	c := fromContext(ctx)
 	if c == nil {
 		return nil, errNotAppEngineContext
@@ -39,8 +39,8 @@ func ClassicContextFromContext(ctx netcontext.Context) (appengine.Context, error
 	return c, nil
 }
 
-func withContext(parent netcontext.Context, c appengine.Context) netcontext.Context {
-	ctx := netcontext.WithValue(parent, &contextKey, c)
+func withContext(parent stdctx.Context, c appengine.Context) stdctx.Context {
+	ctx := stdctx.WithValue(parent, &contextKey, c)
 
 	s := &basepb.StringProto{}
 	c.Call("__go__", "GetNamespace", &basepb.VoidProto{}, s, nil)
@@ -51,7 +51,7 @@ func withContext(parent netcontext.Context, c appengine.Context) netcontext.Cont
 	return ctx
 }
 
-func IncomingHeaders(ctx netcontext.Context) http.Header {
+func IncomingHeaders(ctx stdctx.Context) http.Header {
 	if c := fromContext(ctx); c != nil {
 		if req, ok := c.Request().(*http.Request); ok {
 			return req.Header
@@ -60,11 +60,11 @@ func IncomingHeaders(ctx netcontext.Context) http.Header {
 	return nil
 }
 
-func ReqContext(req *http.Request) netcontext.Context {
-	return WithContext(netcontext.Background(), req)
+func ReqContext(req *http.Request) stdctx.Context {
+	return WithContext(stdctx.Background(), req)
 }
 
-func WithContext(parent netcontext.Context, req *http.Request) netcontext.Context {
+func WithContext(parent stdctx.Context, req *http.Request) stdctx.Context {
 	c := appengine.NewContext(req)
 	return withContext(parent, c)
 }
@@ -84,11 +84,11 @@ func (t *testingContext) Call(service, method string, _, _ appengine_internal.Pr
 }
 func (t *testingContext) Request() interface{} { return t.req }
 
-func ContextForTesting(req *http.Request) netcontext.Context {
-	return withContext(netcontext.Background(), &testingContext{req: req})
+func ContextForTesting(req *http.Request) stdctx.Context {
+	return withContext(stdctx.Background(), &testingContext{req: req})
 }
 
-func Call(ctx netcontext.Context, service, method string, in, out proto.Message) error {
+func Call(ctx stdctx.Context, service, method string, in, out proto.Message) error {
 	if ns := NamespaceFromContext(ctx); ns != "" {
 		if fn, ok := NamespaceMods[service]; ok {
 			fn(in, ns)

--- a/internal/api_common.go
+++ b/internal/api_common.go
@@ -5,7 +5,7 @@
 package internal
 
 import (
-	stdctx "context"
+	"context"
 	"errors"
 	"os"
 
@@ -20,11 +20,11 @@ func (c ctxKey) String() string {
 
 var errNotAppEngineContext = errors.New("not an App Engine context")
 
-type CallOverrideFunc func(ctx stdctx.Context, service, method string, in, out proto.Message) error
+type CallOverrideFunc func(ctx context.Context, service, method string, in, out proto.Message) error
 
 var callOverrideKey = "holds []CallOverrideFunc"
 
-func WithCallOverride(ctx stdctx.Context, f CallOverrideFunc) stdctx.Context {
+func WithCallOverride(ctx context.Context, f CallOverrideFunc) context.Context {
 	// We avoid appending to any existing call override
 	// so we don't risk overwriting a popped stack below.
 	var cofs []CallOverrideFunc
@@ -32,10 +32,10 @@ func WithCallOverride(ctx stdctx.Context, f CallOverrideFunc) stdctx.Context {
 		cofs = append(cofs, uf...)
 	}
 	cofs = append(cofs, f)
-	return stdctx.WithValue(ctx, &callOverrideKey, cofs)
+	return context.WithValue(ctx, &callOverrideKey, cofs)
 }
 
-func callOverrideFromContext(ctx stdctx.Context) (CallOverrideFunc, stdctx.Context, bool) {
+func callOverrideFromContext(ctx context.Context) (CallOverrideFunc, context.Context, bool) {
 	cofs, _ := ctx.Value(&callOverrideKey).([]CallOverrideFunc)
 	if len(cofs) == 0 {
 		return nil, nil, false
@@ -43,7 +43,7 @@ func callOverrideFromContext(ctx stdctx.Context) (CallOverrideFunc, stdctx.Conte
 	// We found a list of overrides; grab the last, and reconstitute a
 	// context that will hide it.
 	f := cofs[len(cofs)-1]
-	ctx = stdctx.WithValue(ctx, &callOverrideKey, cofs[:len(cofs)-1])
+	ctx = context.WithValue(ctx, &callOverrideKey, cofs[:len(cofs)-1])
 	return f, ctx, true
 }
 
@@ -51,35 +51,35 @@ type logOverrideFunc func(level int64, format string, args ...interface{})
 
 var logOverrideKey = "holds a logOverrideFunc"
 
-func WithLogOverride(ctx stdctx.Context, f logOverrideFunc) stdctx.Context {
-	return stdctx.WithValue(ctx, &logOverrideKey, f)
+func WithLogOverride(ctx context.Context, f logOverrideFunc) context.Context {
+	return context.WithValue(ctx, &logOverrideKey, f)
 }
 
 var appIDOverrideKey = "holds a string, being the full app ID"
 
-func WithAppIDOverride(ctx stdctx.Context, appID string) stdctx.Context {
-	return stdctx.WithValue(ctx, &appIDOverrideKey, appID)
+func WithAppIDOverride(ctx context.Context, appID string) context.Context {
+	return context.WithValue(ctx, &appIDOverrideKey, appID)
 }
 
 var apiHostOverrideKey = ctxKey("holds a string, being the alternate API_HOST")
 
-func withAPIHostOverride(ctx stdctx.Context, apiHost string) stdctx.Context {
-	return stdctx.WithValue(ctx, apiHostOverrideKey, apiHost)
+func withAPIHostOverride(ctx context.Context, apiHost string) context.Context {
+	return context.WithValue(ctx, apiHostOverrideKey, apiHost)
 }
 
 var apiPortOverrideKey = ctxKey("holds a string, being the alternate API_PORT")
 
-func withAPIPortOverride(ctx stdctx.Context, apiPort string) stdctx.Context {
-	return stdctx.WithValue(ctx, apiPortOverrideKey, apiPort)
+func withAPIPortOverride(ctx context.Context, apiPort string) context.Context {
+	return context.WithValue(ctx, apiPortOverrideKey, apiPort)
 }
 
 var namespaceKey = "holds the namespace string"
 
-func withNamespace(ctx stdctx.Context, ns string) stdctx.Context {
-	return stdctx.WithValue(ctx, &namespaceKey, ns)
+func withNamespace(ctx context.Context, ns string) context.Context {
+	return context.WithValue(ctx, &namespaceKey, ns)
 }
 
-func NamespaceFromContext(ctx stdctx.Context) string {
+func NamespaceFromContext(ctx context.Context) string {
 	// If there's no namespace, return the empty string.
 	ns, _ := ctx.Value(&namespaceKey).(string)
 	return ns
@@ -88,14 +88,14 @@ func NamespaceFromContext(ctx stdctx.Context) string {
 // FullyQualifiedAppID returns the fully-qualified application ID.
 // This may contain a partition prefix (e.g. "s~" for High Replication apps),
 // or a domain prefix (e.g. "example.com:").
-func FullyQualifiedAppID(ctx stdctx.Context) string {
+func FullyQualifiedAppID(ctx context.Context) string {
 	if id, ok := ctx.Value(&appIDOverrideKey).(string); ok {
 		return id
 	}
 	return fullyQualifiedAppID(ctx)
 }
 
-func Logf(ctx stdctx.Context, level int64, format string, args ...interface{}) {
+func Logf(ctx context.Context, level int64, format string, args ...interface{}) {
 	if f, ok := ctx.Value(&logOverrideKey).(logOverrideFunc); ok {
 		f(level, format, args...)
 		return
@@ -108,7 +108,7 @@ func Logf(ctx stdctx.Context, level int64, format string, args ...interface{}) {
 }
 
 // NamespacedContext wraps a Context to support namespaces.
-func NamespacedContext(ctx stdctx.Context, namespace string) stdctx.Context {
+func NamespacedContext(ctx context.Context, namespace string) context.Context {
 	return withNamespace(ctx, namespace)
 }
 

--- a/internal/api_common.go
+++ b/internal/api_common.go
@@ -5,7 +5,7 @@
 package internal
 
 import (
-	netcontext "context"
+	stdctx "context"
 	"errors"
 	"os"
 
@@ -20,11 +20,11 @@ func (c ctxKey) String() string {
 
 var errNotAppEngineContext = errors.New("not an App Engine context")
 
-type CallOverrideFunc func(ctx netcontext.Context, service, method string, in, out proto.Message) error
+type CallOverrideFunc func(ctx stdctx.Context, service, method string, in, out proto.Message) error
 
 var callOverrideKey = "holds []CallOverrideFunc"
 
-func WithCallOverride(ctx netcontext.Context, f CallOverrideFunc) netcontext.Context {
+func WithCallOverride(ctx stdctx.Context, f CallOverrideFunc) stdctx.Context {
 	// We avoid appending to any existing call override
 	// so we don't risk overwriting a popped stack below.
 	var cofs []CallOverrideFunc
@@ -32,10 +32,10 @@ func WithCallOverride(ctx netcontext.Context, f CallOverrideFunc) netcontext.Con
 		cofs = append(cofs, uf...)
 	}
 	cofs = append(cofs, f)
-	return netcontext.WithValue(ctx, &callOverrideKey, cofs)
+	return stdctx.WithValue(ctx, &callOverrideKey, cofs)
 }
 
-func callOverrideFromContext(ctx netcontext.Context) (CallOverrideFunc, netcontext.Context, bool) {
+func callOverrideFromContext(ctx stdctx.Context) (CallOverrideFunc, stdctx.Context, bool) {
 	cofs, _ := ctx.Value(&callOverrideKey).([]CallOverrideFunc)
 	if len(cofs) == 0 {
 		return nil, nil, false
@@ -43,7 +43,7 @@ func callOverrideFromContext(ctx netcontext.Context) (CallOverrideFunc, netconte
 	// We found a list of overrides; grab the last, and reconstitute a
 	// context that will hide it.
 	f := cofs[len(cofs)-1]
-	ctx = netcontext.WithValue(ctx, &callOverrideKey, cofs[:len(cofs)-1])
+	ctx = stdctx.WithValue(ctx, &callOverrideKey, cofs[:len(cofs)-1])
 	return f, ctx, true
 }
 
@@ -51,35 +51,35 @@ type logOverrideFunc func(level int64, format string, args ...interface{})
 
 var logOverrideKey = "holds a logOverrideFunc"
 
-func WithLogOverride(ctx netcontext.Context, f logOverrideFunc) netcontext.Context {
-	return netcontext.WithValue(ctx, &logOverrideKey, f)
+func WithLogOverride(ctx stdctx.Context, f logOverrideFunc) stdctx.Context {
+	return stdctx.WithValue(ctx, &logOverrideKey, f)
 }
 
 var appIDOverrideKey = "holds a string, being the full app ID"
 
-func WithAppIDOverride(ctx netcontext.Context, appID string) netcontext.Context {
-	return netcontext.WithValue(ctx, &appIDOverrideKey, appID)
+func WithAppIDOverride(ctx stdctx.Context, appID string) stdctx.Context {
+	return stdctx.WithValue(ctx, &appIDOverrideKey, appID)
 }
 
 var apiHostOverrideKey = ctxKey("holds a string, being the alternate API_HOST")
 
-func withAPIHostOverride(ctx netcontext.Context, apiHost string) netcontext.Context {
-	return netcontext.WithValue(ctx, apiHostOverrideKey, apiHost)
+func withAPIHostOverride(ctx stdctx.Context, apiHost string) stdctx.Context {
+	return stdctx.WithValue(ctx, apiHostOverrideKey, apiHost)
 }
 
 var apiPortOverrideKey = ctxKey("holds a string, being the alternate API_PORT")
 
-func withAPIPortOverride(ctx netcontext.Context, apiPort string) netcontext.Context {
-	return netcontext.WithValue(ctx, apiPortOverrideKey, apiPort)
+func withAPIPortOverride(ctx stdctx.Context, apiPort string) stdctx.Context {
+	return stdctx.WithValue(ctx, apiPortOverrideKey, apiPort)
 }
 
 var namespaceKey = "holds the namespace string"
 
-func withNamespace(ctx netcontext.Context, ns string) netcontext.Context {
-	return netcontext.WithValue(ctx, &namespaceKey, ns)
+func withNamespace(ctx stdctx.Context, ns string) stdctx.Context {
+	return stdctx.WithValue(ctx, &namespaceKey, ns)
 }
 
-func NamespaceFromContext(ctx netcontext.Context) string {
+func NamespaceFromContext(ctx stdctx.Context) string {
 	// If there's no namespace, return the empty string.
 	ns, _ := ctx.Value(&namespaceKey).(string)
 	return ns
@@ -88,14 +88,14 @@ func NamespaceFromContext(ctx netcontext.Context) string {
 // FullyQualifiedAppID returns the fully-qualified application ID.
 // This may contain a partition prefix (e.g. "s~" for High Replication apps),
 // or a domain prefix (e.g. "example.com:").
-func FullyQualifiedAppID(ctx netcontext.Context) string {
+func FullyQualifiedAppID(ctx stdctx.Context) string {
 	if id, ok := ctx.Value(&appIDOverrideKey).(string); ok {
 		return id
 	}
 	return fullyQualifiedAppID(ctx)
 }
 
-func Logf(ctx netcontext.Context, level int64, format string, args ...interface{}) {
+func Logf(ctx stdctx.Context, level int64, format string, args ...interface{}) {
 	if f, ok := ctx.Value(&logOverrideKey).(logOverrideFunc); ok {
 		f(level, format, args...)
 		return
@@ -108,7 +108,7 @@ func Logf(ctx netcontext.Context, level int64, format string, args ...interface{
 }
 
 // NamespacedContext wraps a Context to support namespaces.
-func NamespacedContext(ctx netcontext.Context, namespace string) netcontext.Context {
+func NamespacedContext(ctx stdctx.Context, namespace string) stdctx.Context {
 	return withNamespace(ctx, namespace)
 }
 

--- a/internal/api_test.go
+++ b/internal/api_test.go
@@ -10,7 +10,7 @@ package internal
 import (
 	"bufio"
 	"bytes"
-	netcontext "context"
+	stdctx "context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -235,7 +235,7 @@ func TestAPICallRPCFailure(t *testing.T) {
 	}
 	f.hang = make(chan int) // only for RunSlowly
 	for _, tc := range testCases {
-		ctx, _ := netcontext.WithTimeout(toContext(c), 100*time.Millisecond)
+		ctx, _ := stdctx.WithTimeout(toContext(c), 100*time.Millisecond)
 		err := Call(ctx, "errors", tc.method, &basepb.VoidProto{}, &basepb.VoidProto{})
 		ce, ok := err.(*CallError)
 		if !ok {
@@ -256,7 +256,7 @@ func TestAPICallDialFailure(t *testing.T) {
 	// This should time out quickly, not hang forever.
 	// We intentially don't set up the fakeAPIHandler for this test to cause the dail failure.
 	start := time.Now()
-	err := Call(netcontext.Background(), "foo", "bar", &basepb.VoidProto{}, &basepb.VoidProto{})
+	err := Call(stdctx.Background(), "foo", "bar", &basepb.VoidProto{}, &basepb.VoidProto{})
 	const max = 1 * time.Second
 	if taken := time.Since(start); taken > max {
 		t.Errorf("Dial hang took too long: %v > %v", taken, max)
@@ -288,7 +288,7 @@ func TestDelayedLogFlushing(t *testing.T) {
 			path := "/slow_log_" + tc.logToLogservice
 
 			http.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
-				logC := WithContext(netcontext.Background(), r)
+				logC := WithContext(stdctx.Background(), r)
 				Logf(logC, 1, "It's a lovely day.")
 				w.WriteHeader(200)
 				time.Sleep(1200 * time.Millisecond)
@@ -349,7 +349,7 @@ func TestLogFlushing(t *testing.T) {
 
 			path := "/quick_log_" + tc.logToLogservice
 			http.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
-				logC := WithContext(netcontext.Background(), r)
+				logC := WithContext(stdctx.Background(), r)
 				Logf(logC, 1, "It's a lovely day.")
 				w.WriteHeader(200)
 				w.Write(make([]byte, 100<<10)) // write 100 KB to force HTTP flush
@@ -458,7 +458,7 @@ func TestAPICallAllocations(t *testing.T) {
 	res := &basepb.StringProto{}
 	var apiErr error
 	avg := testing.AllocsPerRun(100, func() {
-		ctx, _ := netcontext.WithTimeout(toContext(c), 100*time.Millisecond)
+		ctx, _ := stdctx.WithTimeout(toContext(c), 100*time.Millisecond)
 		if err := Call(ctx, "actordb", "LookupActor", req, res); err != nil && apiErr == nil {
 			apiErr = err // get the first error only
 		}

--- a/internal/identity.go
+++ b/internal/identity.go
@@ -5,9 +5,8 @@
 package internal
 
 import (
+	stdctx "context"
 	"os"
-
-	netcontext "golang.org/x/net/context"
 )
 
 var (
@@ -23,7 +22,7 @@ var (
 
 // AppID is the implementation of the wrapper function of the same name in
 // ../identity.go. See that file for commentary.
-func AppID(c netcontext.Context) string {
+func AppID(c stdctx.Context) string {
 	return appID(FullyQualifiedAppID(c))
 }
 

--- a/internal/identity.go
+++ b/internal/identity.go
@@ -5,7 +5,7 @@
 package internal
 
 import (
-	stdctx "context"
+	"context"
 	"os"
 )
 
@@ -22,7 +22,7 @@ var (
 
 // AppID is the implementation of the wrapper function of the same name in
 // ../identity.go. See that file for commentary.
-func AppID(c stdctx.Context) string {
+func AppID(c context.Context) string {
 	return appID(FullyQualifiedAppID(c))
 }
 

--- a/internal/identity_classic.go
+++ b/internal/identity_classic.go
@@ -8,16 +8,16 @@
 package internal
 
 import (
-	"appengine"
+	"context"
 
-	netcontext "golang.org/x/net/context"
+	"appengine"
 )
 
 func init() {
 	appengineStandard = true
 }
 
-func DefaultVersionHostname(ctx netcontext.Context) string {
+func DefaultVersionHostname(ctx context.Context) string {
 	c := fromContext(ctx)
 	if c == nil {
 		panic(errNotAppEngineContext)
@@ -25,12 +25,12 @@ func DefaultVersionHostname(ctx netcontext.Context) string {
 	return appengine.DefaultVersionHostname(c)
 }
 
-func Datacenter(_ netcontext.Context) string { return appengine.Datacenter() }
-func ServerSoftware() string                 { return appengine.ServerSoftware() }
-func InstanceID() string                     { return appengine.InstanceID() }
-func IsDevAppServer() bool                   { return appengine.IsDevAppServer() }
+func Datacenter(_ context.Context) string { return appengine.Datacenter() }
+func ServerSoftware() string              { return appengine.ServerSoftware() }
+func InstanceID() string                  { return appengine.InstanceID() }
+func IsDevAppServer() bool                { return appengine.IsDevAppServer() }
 
-func RequestID(ctx netcontext.Context) string {
+func RequestID(ctx context.Context) string {
 	c := fromContext(ctx)
 	if c == nil {
 		panic(errNotAppEngineContext)
@@ -38,14 +38,14 @@ func RequestID(ctx netcontext.Context) string {
 	return appengine.RequestID(c)
 }
 
-func ModuleName(ctx netcontext.Context) string {
+func ModuleName(ctx context.Context) string {
 	c := fromContext(ctx)
 	if c == nil {
 		panic(errNotAppEngineContext)
 	}
 	return appengine.ModuleName(c)
 }
-func VersionID(ctx netcontext.Context) string {
+func VersionID(ctx context.Context) string {
 	c := fromContext(ctx)
 	if c == nil {
 		panic(errNotAppEngineContext)
@@ -53,7 +53,7 @@ func VersionID(ctx netcontext.Context) string {
 	return appengine.VersionID(c)
 }
 
-func fullyQualifiedAppID(ctx netcontext.Context) string {
+func fullyQualifiedAppID(ctx context.Context) string {
 	c := fromContext(ctx)
 	if c == nil {
 		panic(errNotAppEngineContext)

--- a/internal/identity_vm.go
+++ b/internal/identity_vm.go
@@ -8,12 +8,11 @@
 package internal
 
 import (
+	stdctx "context"
 	"log"
 	"net/http"
 	"os"
 	"strings"
-
-	netcontext "golang.org/x/net/context"
 )
 
 // These functions are implementations of the wrapper functions
@@ -25,7 +24,7 @@ const (
 	hDatacenter             = "X-AppEngine-Datacenter"
 )
 
-func ctxHeaders(ctx netcontext.Context) http.Header {
+func ctxHeaders(ctx stdctx.Context) http.Header {
 	c := fromContext(ctx)
 	if c == nil {
 		return nil
@@ -33,15 +32,15 @@ func ctxHeaders(ctx netcontext.Context) http.Header {
 	return c.Request().Header
 }
 
-func DefaultVersionHostname(ctx netcontext.Context) string {
+func DefaultVersionHostname(ctx stdctx.Context) string {
 	return ctxHeaders(ctx).Get(hDefaultVersionHostname)
 }
 
-func RequestID(ctx netcontext.Context) string {
+func RequestID(ctx stdctx.Context) string {
 	return ctxHeaders(ctx).Get(hRequestLogId)
 }
 
-func Datacenter(ctx netcontext.Context) string {
+func Datacenter(ctx stdctx.Context) string {
 	if dc := ctxHeaders(ctx).Get(hDatacenter); dc != "" {
 		return dc
 	}
@@ -72,7 +71,7 @@ func ServerSoftware() string {
 
 // TODO(dsymonds): Remove the metadata fetches.
 
-func ModuleName(_ netcontext.Context) string {
+func ModuleName(_ stdctx.Context) string {
 	if s := os.Getenv("GAE_MODULE_NAME"); s != "" {
 		return s
 	}
@@ -82,7 +81,7 @@ func ModuleName(_ netcontext.Context) string {
 	return string(mustGetMetadata("instance/attributes/gae_backend_name"))
 }
 
-func VersionID(_ netcontext.Context) string {
+func VersionID(_ stdctx.Context) string {
 	if s1, s2 := os.Getenv("GAE_MODULE_VERSION"), os.Getenv("GAE_MINOR_VERSION"); s1 != "" && s2 != "" {
 		return s1 + "." + s2
 	}
@@ -113,7 +112,7 @@ func partitionlessAppID() string {
 	return string(mustGetMetadata("instance/attributes/gae_project"))
 }
 
-func fullyQualifiedAppID(_ netcontext.Context) string {
+func fullyQualifiedAppID(_ stdctx.Context) string {
 	if s := os.Getenv("GAE_APPLICATION"); s != "" {
 		return s
 	}

--- a/internal/identity_vm.go
+++ b/internal/identity_vm.go
@@ -8,7 +8,7 @@
 package internal
 
 import (
-	stdctx "context"
+	"context"
 	"log"
 	"net/http"
 	"os"
@@ -24,7 +24,7 @@ const (
 	hDatacenter             = "X-AppEngine-Datacenter"
 )
 
-func ctxHeaders(ctx stdctx.Context) http.Header {
+func ctxHeaders(ctx context.Context) http.Header {
 	c := fromContext(ctx)
 	if c == nil {
 		return nil
@@ -32,15 +32,15 @@ func ctxHeaders(ctx stdctx.Context) http.Header {
 	return c.Request().Header
 }
 
-func DefaultVersionHostname(ctx stdctx.Context) string {
+func DefaultVersionHostname(ctx context.Context) string {
 	return ctxHeaders(ctx).Get(hDefaultVersionHostname)
 }
 
-func RequestID(ctx stdctx.Context) string {
+func RequestID(ctx context.Context) string {
 	return ctxHeaders(ctx).Get(hRequestLogId)
 }
 
-func Datacenter(ctx stdctx.Context) string {
+func Datacenter(ctx context.Context) string {
 	if dc := ctxHeaders(ctx).Get(hDatacenter); dc != "" {
 		return dc
 	}
@@ -71,7 +71,7 @@ func ServerSoftware() string {
 
 // TODO(dsymonds): Remove the metadata fetches.
 
-func ModuleName(_ stdctx.Context) string {
+func ModuleName(_ context.Context) string {
 	if s := os.Getenv("GAE_MODULE_NAME"); s != "" {
 		return s
 	}
@@ -81,7 +81,7 @@ func ModuleName(_ stdctx.Context) string {
 	return string(mustGetMetadata("instance/attributes/gae_backend_name"))
 }
 
-func VersionID(_ stdctx.Context) string {
+func VersionID(_ context.Context) string {
 	if s1, s2 := os.Getenv("GAE_MODULE_VERSION"), os.Getenv("GAE_MINOR_VERSION"); s1 != "" && s2 != "" {
 		return s1 + "." + s2
 	}
@@ -112,7 +112,7 @@ func partitionlessAppID() string {
 	return string(mustGetMetadata("instance/attributes/gae_project"))
 }
 
-func fullyQualifiedAppID(_ stdctx.Context) string {
+func fullyQualifiedAppID(_ context.Context) string {
 	if s := os.Getenv("GAE_APPLICATION"); s != "" {
 		return s
 	}

--- a/internal/net_test.go
+++ b/internal/net_test.go
@@ -8,7 +8,7 @@
 package internal
 
 import (
-	stdctx "context"
+	"context"
 	"sync"
 	"testing"
 	"time"
@@ -45,7 +45,7 @@ func TestDialLimit(t *testing.T) {
 	}
 	time.Sleep(50 * time.Millisecond) // let those two RPCs start
 
-	ctx, _ := stdctx.WithTimeout(toContext(c), 50*time.Millisecond)
+	ctx, _ := context.WithTimeout(toContext(c), 50*time.Millisecond)
 	err := Call(ctx, "errors", "Non200", &basepb.VoidProto{}, &basepb.VoidProto{})
 	if err != errTimeout {
 		t.Errorf("Non200 RPC returned with err %v, want errTimeout", err)

--- a/internal/net_test.go
+++ b/internal/net_test.go
@@ -8,11 +8,10 @@
 package internal
 
 import (
+	stdctx "context"
 	"sync"
 	"testing"
 	"time"
-
-	netcontext "golang.org/x/net/context"
 
 	basepb "google.golang.org/appengine/internal/base"
 )
@@ -46,7 +45,7 @@ func TestDialLimit(t *testing.T) {
 	}
 	time.Sleep(50 * time.Millisecond) // let those two RPCs start
 
-	ctx, _ := netcontext.WithTimeout(toContext(c), 50*time.Millisecond)
+	ctx, _ := stdctx.WithTimeout(toContext(c), 50*time.Millisecond)
 	err := Call(ctx, "errors", "Non200", &basepb.VoidProto{}, &basepb.VoidProto{})
 	if err != errTimeout {
 		t.Errorf("Non200 RPC returned with err %v, want errTimeout", err)

--- a/internal/transaction.go
+++ b/internal/transaction.go
@@ -7,11 +7,11 @@ package internal
 // This file implements hooks for applying datastore transactions.
 
 import (
+	stdctx "context"
 	"errors"
 	"reflect"
 
 	"github.com/golang/protobuf/proto"
-	netcontext "golang.org/x/net/context"
 
 	basepb "google.golang.org/appengine/internal/base"
 	pb "google.golang.org/appengine/internal/datastore"
@@ -38,13 +38,13 @@ func applyTransaction(pb proto.Message, t *pb.Transaction) {
 
 var transactionKey = "used for *Transaction"
 
-func transactionFromContext(ctx netcontext.Context) *transaction {
+func transactionFromContext(ctx stdctx.Context) *transaction {
 	t, _ := ctx.Value(&transactionKey).(*transaction)
 	return t
 }
 
-func withTransaction(ctx netcontext.Context, t *transaction) netcontext.Context {
-	return netcontext.WithValue(ctx, &transactionKey, t)
+func withTransaction(ctx stdctx.Context, t *transaction) stdctx.Context {
+	return stdctx.WithValue(ctx, &transactionKey, t)
 }
 
 type transaction struct {
@@ -54,7 +54,7 @@ type transaction struct {
 
 var ErrConcurrentTransaction = errors.New("internal: concurrent transaction")
 
-func RunTransactionOnce(c netcontext.Context, f func(netcontext.Context) error, xg bool, readOnly bool, previousTransaction *pb.Transaction) (*pb.Transaction, error) {
+func RunTransactionOnce(c stdctx.Context, f func(stdctx.Context) error, xg bool, readOnly bool, previousTransaction *pb.Transaction) (*pb.Transaction, error) {
 	if transactionFromContext(c) != nil {
 		return nil, errors.New("nested transactions are not supported")
 	}

--- a/internal/transaction.go
+++ b/internal/transaction.go
@@ -7,7 +7,7 @@ package internal
 // This file implements hooks for applying datastore transactions.
 
 import (
-	stdctx "context"
+	"context"
 	"errors"
 	"reflect"
 
@@ -38,13 +38,13 @@ func applyTransaction(pb proto.Message, t *pb.Transaction) {
 
 var transactionKey = "used for *Transaction"
 
-func transactionFromContext(ctx stdctx.Context) *transaction {
+func transactionFromContext(ctx context.Context) *transaction {
 	t, _ := ctx.Value(&transactionKey).(*transaction)
 	return t
 }
 
-func withTransaction(ctx stdctx.Context, t *transaction) stdctx.Context {
-	return stdctx.WithValue(ctx, &transactionKey, t)
+func withTransaction(ctx context.Context, t *transaction) context.Context {
+	return context.WithValue(ctx, &transactionKey, t)
 }
 
 type transaction struct {
@@ -54,7 +54,7 @@ type transaction struct {
 
 var ErrConcurrentTransaction = errors.New("internal: concurrent transaction")
 
-func RunTransactionOnce(c stdctx.Context, f func(stdctx.Context) error, xg bool, readOnly bool, previousTransaction *pb.Transaction) (*pb.Transaction, error) {
+func RunTransactionOnce(c context.Context, f func(context.Context) error, xg bool, readOnly bool, previousTransaction *pb.Transaction) (*pb.Transaction, error) {
 	if transactionFromContext(c) != nil {
 		return nil, errors.New("nested transactions are not supported")
 	}

--- a/log/api.go
+++ b/log/api.go
@@ -7,7 +7,7 @@ package log
 // This file implements the logging API.
 
 import (
-	"golang.org/x/net/context"
+	"context"
 
 	"google.golang.org/appengine/internal"
 )

--- a/log/log.go
+++ b/log/log.go
@@ -30,13 +30,13 @@ Example:
 package log // import "google.golang.org/appengine/log"
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
 	"time"
 
 	"github.com/golang/protobuf/proto"
-	"golang.org/x/net/context"
 
 	"google.golang.org/appengine"
 	"google.golang.org/appengine/internal"

--- a/mail/mail.go
+++ b/mail/mail.go
@@ -21,10 +21,10 @@ Example:
 package mail // import "google.golang.org/appengine/mail"
 
 import (
+	"context"
 	"net/mail"
 
 	"github.com/golang/protobuf/proto"
-	"golang.org/x/net/context"
 
 	"google.golang.org/appengine/internal"
 	bpb "google.golang.org/appengine/internal/base"

--- a/memcache/memcache.go
+++ b/memcache/memcache.go
@@ -30,13 +30,13 @@ package memcache // import "google.golang.org/appengine/memcache"
 
 import (
 	"bytes"
+	"context"
 	"encoding/gob"
 	"encoding/json"
 	"errors"
 	"time"
 
 	"github.com/golang/protobuf/proto"
-	"golang.org/x/net/context"
 
 	"google.golang.org/appengine"
 	"google.golang.org/appengine/internal"

--- a/module/module.go
+++ b/module/module.go
@@ -11,8 +11,9 @@ including the module name.
 package module // import "google.golang.org/appengine/module"
 
 import (
+	"context"
+
 	"github.com/golang/protobuf/proto"
-	"golang.org/x/net/context"
 
 	"google.golang.org/appengine/internal"
 	pb "google.golang.org/appengine/internal/modules"

--- a/namespace.go
+++ b/namespace.go
@@ -5,10 +5,9 @@
 package appengine
 
 import (
+	"context"
 	"fmt"
 	"regexp"
-
-	"golang.org/x/net/context"
 
 	"google.golang.org/appengine/internal"
 )

--- a/namespace_test.go
+++ b/namespace_test.go
@@ -5,9 +5,8 @@
 package appengine
 
 import (
+	"context"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
 func TestNamespaceValidity(t *testing.T) {

--- a/remote_api/client.go
+++ b/remote_api/client.go
@@ -9,6 +9,7 @@ package remote_api
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -21,7 +22,6 @@ import (
 	"time"
 
 	"github.com/golang/protobuf/proto"
-	"golang.org/x/net/context"
 
 	"google.golang.org/appengine/internal"
 	pb "google.golang.org/appengine/internal/remote_api"

--- a/remote_api/client_test.go
+++ b/remote_api/client_test.go
@@ -5,11 +5,11 @@
 package remote_api
 
 import (
+	"context"
 	"log"
 	"net/http"
 	"testing"
 
-	"golang.org/x/net/context"
 	"google.golang.org/appengine/datastore"
 )
 

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -11,9 +11,8 @@ This package does not work on App Engine "flexible environment".
 package runtime // import "google.golang.org/appengine/runtime"
 
 import (
+	"context"
 	"net/http"
-
-	"golang.org/x/net/context"
 
 	"google.golang.org/appengine"
 	"google.golang.org/appengine/internal"

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -5,6 +5,7 @@
 package runtime
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -12,7 +13,6 @@ import (
 	"time"
 
 	"github.com/golang/protobuf/proto"
-	"golang.org/x/net/context"
 
 	"google.golang.org/appengine/internal/aetesting"
 	pb "google.golang.org/appengine/internal/system"

--- a/search/search.go
+++ b/search/search.go
@@ -11,6 +11,7 @@ package search // import "google.golang.org/appengine/search"
 // time.Time)? _MAXIMUM_STRING_LENGTH?
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"math"
@@ -22,7 +23,6 @@ import (
 	"unicode/utf8"
 
 	"github.com/golang/protobuf/proto"
-	"golang.org/x/net/context"
 
 	"google.golang.org/appengine"
 	"google.golang.org/appengine/internal"

--- a/socket/socket_classic.go
+++ b/socket/socket_classic.go
@@ -8,6 +8,7 @@
 package socket
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net"
@@ -15,7 +16,6 @@ import (
 	"time"
 
 	"github.com/golang/protobuf/proto"
-	"golang.org/x/net/context"
 	"google.golang.org/appengine/internal"
 
 	pb "google.golang.org/appengine/internal/socket"

--- a/socket/socket_vm.go
+++ b/socket/socket_vm.go
@@ -8,10 +8,9 @@
 package socket
 
 import (
+	"context"
 	"net"
 	"time"
-
-	"golang.org/x/net/context"
 )
 
 // Dial connects to the address addr on the network protocol.

--- a/taskqueue/taskqueue.go
+++ b/taskqueue/taskqueue.go
@@ -17,6 +17,7 @@ taskqueue operation is to add a single POST task, NewPOSTTask makes it easy.
 package taskqueue // import "google.golang.org/appengine/taskqueue"
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -25,7 +26,6 @@ import (
 	"time"
 
 	"github.com/golang/protobuf/proto"
-	"golang.org/x/net/context"
 
 	"google.golang.org/appengine"
 	"google.golang.org/appengine/internal"

--- a/timeout.go
+++ b/timeout.go
@@ -4,7 +4,7 @@
 
 package appengine
 
-import "golang.org/x/net/context"
+import "context"
 
 // IsTimeoutError reports whether err is a timeout error.
 func IsTimeoutError(err error) bool {

--- a/urlfetch/urlfetch.go
+++ b/urlfetch/urlfetch.go
@@ -7,6 +7,7 @@
 package urlfetch // import "google.golang.org/appengine/urlfetch"
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -18,7 +19,6 @@ import (
 	"time"
 
 	"github.com/golang/protobuf/proto"
-	"golang.org/x/net/context"
 
 	"google.golang.org/appengine/internal"
 	pb "google.golang.org/appengine/internal/urlfetch"

--- a/user/oauth.go
+++ b/user/oauth.go
@@ -5,7 +5,7 @@
 package user
 
 import (
-	"golang.org/x/net/context"
+	"context"
 
 	"google.golang.org/appengine/internal"
 	pb "google.golang.org/appengine/internal/user"

--- a/user/user.go
+++ b/user/user.go
@@ -6,10 +6,10 @@
 package user // import "google.golang.org/appengine/user"
 
 import (
+	"context"
 	"strings"
 
 	"github.com/golang/protobuf/proto"
-	"golang.org/x/net/context"
 
 	"google.golang.org/appengine/internal"
 	pb "google.golang.org/appengine/internal/user"

--- a/user/user_classic.go
+++ b/user/user_classic.go
@@ -10,7 +10,7 @@ package user
 import (
 	"appengine/user"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"google.golang.org/appengine/internal"
 )

--- a/user/user_vm.go
+++ b/user/user_vm.go
@@ -8,7 +8,7 @@
 package user
 
 import (
-	"golang.org/x/net/context"
+	"context"
 
 	"google.golang.org/appengine/internal"
 )

--- a/v2/README.md
+++ b/v2/README.md
@@ -51,7 +51,7 @@ code importing `appengine/datastore` will now need to import `google.golang.org/
 Most App Engine services are available with exactly the same API.
 A few APIs were cleaned up, and there are some differences:
 
-* `appengine.Context` has been replaced with the `Context` type from `golang.org/x/net/context`.
+* `appengine.Context` has been replaced with the `Context` type from `context`.
 * Logging methods that were on `appengine.Context` are now functions in `google.golang.org/appengine/log`.
 * `appengine.Timeout` has been removed. Use `context.WithTimeout` instead.
 * `appengine.Datacenter` now takes a `context.Context` argument.

--- a/v2/cmd/aefix/ae.go
+++ b/v2/cmd/aefix/ae.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	ctxPackage = "golang.org/x/net/context"
+	ctxPackage = "context"
 
 	newPackageBase = "google.golang.org/"
 )

--- a/v2/cmd/aefix/ae_test.go
+++ b/v2/cmd/aefix/ae_test.go
@@ -38,10 +38,10 @@ func f(w http.ResponseWriter, r *http.Request) {
 		Out: `package foo
 
 import (
+	"context"
 	"net/http"
 	"time"
 
-	"golang.org/x/net/context"
 	"google.golang.org/appengine/v2"
 	"google.golang.org/appengine/v2/datastore"
 	"google.golang.org/appengine/v2/log"
@@ -74,7 +74,7 @@ func LogSomething(c2 appengine.Context) {
 		Out: `package foo
 
 import (
-	"golang.org/x/net/context"
+	"context"
 	"google.golang.org/appengine/v2/log"
 )
 
@@ -102,7 +102,7 @@ func f(ctx appengine.Context) {
 		Out: `package foo
 
 import (
-	"golang.org/x/net/context"
+	"context"
 	"google.golang.org/appengine/v2/taskqueue"
 )
 
@@ -131,7 +131,7 @@ func f(ctx appengine.Context, w io.Writer) {
 		Out: `package foo
 
 import (
-	"golang.org/x/net/context"
+	"context"
 	"google.golang.org/appengine/v2"
 	"io"
 )

--- a/v2/delay/delay.go
+++ b/v2/delay/delay.go
@@ -33,7 +33,7 @@ package delay // import "google.golang.org/appengine/v2/delay"
 
 import (
 	"bytes"
-	stdctx "context"
+	"context"
 	"encoding/gob"
 	"errors"
 	"fmt"
@@ -45,8 +45,6 @@ import (
 	"regexp"
 	"runtime"
 	"strings"
-
-	"golang.org/x/net/context"
 
 	"google.golang.org/appengine/v2"
 	"google.golang.org/appengine/v2/internal"
@@ -83,12 +81,11 @@ var (
 
 	// context keys
 	headersContextKey contextKey = 0
-	stdContextType               = reflect.TypeOf((*stdctx.Context)(nil)).Elem()
-	netContextType               = reflect.TypeOf((*context.Context)(nil)).Elem()
+	stdContextType               = reflect.TypeOf((*context.Context)(nil)).Elem()
 )
 
 func isContext(t reflect.Type) bool {
-	return t == stdContextType || t == netContextType
+	return t == stdContextType
 }
 
 var modVersionPat = regexp.MustCompile("@v[^/]+")

--- a/v2/delay/delay_test.go
+++ b/v2/delay/delay_test.go
@@ -6,7 +6,7 @@ package delay
 
 import (
 	"bytes"
-	stdctx "context"
+	"context"
 	"encoding/gob"
 	"errors"
 	"fmt"
@@ -18,7 +18,6 @@ import (
 	"testing"
 
 	"github.com/golang/protobuf/proto"
-	"golang.org/x/net/context"
 
 	"google.golang.org/appengine/v2/internal"
 	"google.golang.org/appengine/v2/taskqueue"
@@ -116,12 +115,12 @@ var (
 	requestFunc     = Func("requestFunc", requestF)
 	requestRegister = MustRegister("requestRegister", requestF)
 
-	stdCtxRuns = 0
-	stdCtxF    = func(c stdctx.Context) {
-		stdCtxRuns++
+	contextRuns = 0
+	contextF    = func(c context.Context) {
+		contextRuns++
 	}
-	stdCtxFunc     = Func("stdctxFunc", stdCtxF)
-	stdCtxRegister = MustRegister("stdctxRegister", stdCtxF)
+	contextFunc     = Func("contextFunc", contextF)
+	contextRegister = MustRegister("contextRegister", contextF)
 )
 
 type fakeContext struct {
@@ -505,9 +504,9 @@ func TestStandardContext(t *testing.T) {
 		return tk, nil
 	}
 
-	for _, testTarget := range []*Function{stdCtxFunc, stdCtxRegister} {
+	for _, testTarget := range []*Function{contextFunc, contextRegister} {
 		c := newFakeContext()
-		stdCtxRuns = 0 // reset state
+		contextRuns = 0 // reset state
 		if err := testTarget.Call(c.ctx); err != nil {
 			t.Fatal("Function.Call:", err)
 		}
@@ -520,8 +519,8 @@ func TestStandardContext(t *testing.T) {
 		rw := httptest.NewRecorder()
 		runFunc(c.ctx, rw, req)
 
-		if stdCtxRuns != 1 {
-			t.Errorf("stdCtxRuns: got %d, want 1", stdCtxRuns)
+		if contextRuns != 1 {
+			t.Errorf("contextRuns: got %d, want 1", contextRuns)
 		}
 	}
 }

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -4,6 +4,5 @@ go 1.11
 
 require (
 	github.com/golang/protobuf v1.3.1
-	golang.org/x/net v0.0.0-20220708220712-1185a9018129
 	golang.org/x/text v0.3.7
 )

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -1,10 +1,5 @@
 github.com/golang/protobuf v1.3.1 h1:YF8+flBXS5eO826T4nzqPrxfhQThhXl0YzfuUPu4SBg=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
-golang.org/x/net v0.0.0-20220708220712-1185a9018129 h1:vucSRfWwTsoXro7P+3Cjlr6flUMtzCwzlvkxEQtHHB0=
-golang.org/x/net v0.0.0-20220708220712-1185a9018129/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
-golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/v2/internal/api_common.go
+++ b/v2/internal/api_common.go
@@ -5,7 +5,7 @@
 package internal
 
 import (
-	netcontext "context"
+	stdctx "context"
 	"errors"
 	"os"
 
@@ -20,11 +20,11 @@ func (c ctxKey) String() string {
 
 var errNotAppEngineContext = errors.New("not an App Engine context")
 
-type CallOverrideFunc func(ctx netcontext.Context, service, method string, in, out proto.Message) error
+type CallOverrideFunc func(ctx stdctx.Context, service, method string, in, out proto.Message) error
 
 var callOverrideKey = "holds []CallOverrideFunc"
 
-func WithCallOverride(ctx netcontext.Context, f CallOverrideFunc) netcontext.Context {
+func WithCallOverride(ctx stdctx.Context, f CallOverrideFunc) stdctx.Context {
 	// We avoid appending to any existing call override
 	// so we don't risk overwriting a popped stack below.
 	var cofs []CallOverrideFunc
@@ -32,10 +32,10 @@ func WithCallOverride(ctx netcontext.Context, f CallOverrideFunc) netcontext.Con
 		cofs = append(cofs, uf...)
 	}
 	cofs = append(cofs, f)
-	return netcontext.WithValue(ctx, &callOverrideKey, cofs)
+	return stdctx.WithValue(ctx, &callOverrideKey, cofs)
 }
 
-func callOverrideFromContext(ctx netcontext.Context) (CallOverrideFunc, netcontext.Context, bool) {
+func callOverrideFromContext(ctx stdctx.Context) (CallOverrideFunc, stdctx.Context, bool) {
 	cofs, _ := ctx.Value(&callOverrideKey).([]CallOverrideFunc)
 	if len(cofs) == 0 {
 		return nil, nil, false
@@ -43,7 +43,7 @@ func callOverrideFromContext(ctx netcontext.Context) (CallOverrideFunc, netconte
 	// We found a list of overrides; grab the last, and reconstitute a
 	// context that will hide it.
 	f := cofs[len(cofs)-1]
-	ctx = netcontext.WithValue(ctx, &callOverrideKey, cofs[:len(cofs)-1])
+	ctx = stdctx.WithValue(ctx, &callOverrideKey, cofs[:len(cofs)-1])
 	return f, ctx, true
 }
 
@@ -51,35 +51,35 @@ type logOverrideFunc func(level int64, format string, args ...interface{})
 
 var logOverrideKey = "holds a logOverrideFunc"
 
-func WithLogOverride(ctx netcontext.Context, f logOverrideFunc) netcontext.Context {
-	return netcontext.WithValue(ctx, &logOverrideKey, f)
+func WithLogOverride(ctx stdctx.Context, f logOverrideFunc) stdctx.Context {
+	return stdctx.WithValue(ctx, &logOverrideKey, f)
 }
 
 var appIDOverrideKey = "holds a string, being the full app ID"
 
-func WithAppIDOverride(ctx netcontext.Context, appID string) netcontext.Context {
-	return netcontext.WithValue(ctx, &appIDOverrideKey, appID)
+func WithAppIDOverride(ctx stdctx.Context, appID string) stdctx.Context {
+	return stdctx.WithValue(ctx, &appIDOverrideKey, appID)
 }
 
 var apiHostOverrideKey = ctxKey("holds a string, being the alternate API_HOST")
 
-func withAPIHostOverride(ctx netcontext.Context, apiHost string) netcontext.Context {
-	return netcontext.WithValue(ctx, apiHostOverrideKey, apiHost)
+func withAPIHostOverride(ctx stdctx.Context, apiHost string) stdctx.Context {
+	return stdctx.WithValue(ctx, apiHostOverrideKey, apiHost)
 }
 
 var apiPortOverrideKey = ctxKey("holds a string, being the alternate API_PORT")
 
-func withAPIPortOverride(ctx netcontext.Context, apiPort string) netcontext.Context {
-	return netcontext.WithValue(ctx, apiPortOverrideKey, apiPort)
+func withAPIPortOverride(ctx stdctx.Context, apiPort string) stdctx.Context {
+	return stdctx.WithValue(ctx, apiPortOverrideKey, apiPort)
 }
 
 var namespaceKey = "holds the namespace string"
 
-func withNamespace(ctx netcontext.Context, ns string) netcontext.Context {
-	return netcontext.WithValue(ctx, &namespaceKey, ns)
+func withNamespace(ctx stdctx.Context, ns string) stdctx.Context {
+	return stdctx.WithValue(ctx, &namespaceKey, ns)
 }
 
-func NamespaceFromContext(ctx netcontext.Context) string {
+func NamespaceFromContext(ctx stdctx.Context) string {
 	// If there's no namespace, return the empty string.
 	ns, _ := ctx.Value(&namespaceKey).(string)
 	return ns
@@ -88,14 +88,14 @@ func NamespaceFromContext(ctx netcontext.Context) string {
 // FullyQualifiedAppID returns the fully-qualified application ID.
 // This may contain a partition prefix (e.g. "s~" for High Replication apps),
 // or a domain prefix (e.g. "example.com:").
-func FullyQualifiedAppID(ctx netcontext.Context) string {
+func FullyQualifiedAppID(ctx stdctx.Context) string {
 	if id, ok := ctx.Value(&appIDOverrideKey).(string); ok {
 		return id
 	}
 	return fullyQualifiedAppID(ctx)
 }
 
-func Logf(ctx netcontext.Context, level int64, format string, args ...interface{}) {
+func Logf(ctx stdctx.Context, level int64, format string, args ...interface{}) {
 	if f, ok := ctx.Value(&logOverrideKey).(logOverrideFunc); ok {
 		f(level, format, args...)
 		return
@@ -108,7 +108,7 @@ func Logf(ctx netcontext.Context, level int64, format string, args ...interface{
 }
 
 // NamespacedContext wraps a Context to support namespaces.
-func NamespacedContext(ctx netcontext.Context, namespace string) netcontext.Context {
+func NamespacedContext(ctx stdctx.Context, namespace string) stdctx.Context {
 	return withNamespace(ctx, namespace)
 }
 

--- a/v2/internal/api_common.go
+++ b/v2/internal/api_common.go
@@ -5,7 +5,7 @@
 package internal
 
 import (
-	stdctx "context"
+	"context"
 	"errors"
 	"os"
 
@@ -15,16 +15,16 @@ import (
 type ctxKey string
 
 func (c ctxKey) String() string {
-	return "appengine context key: " + string(c)
+	return "appengine aeContext key: " + string(c)
 }
 
-var errNotAppEngineContext = errors.New("not an App Engine context")
+var errNotAppEngineContext = errors.New("not an App Engine aeContext")
 
-type CallOverrideFunc func(ctx stdctx.Context, service, method string, in, out proto.Message) error
+type CallOverrideFunc func(ctx context.Context, service, method string, in, out proto.Message) error
 
 var callOverrideKey = "holds []CallOverrideFunc"
 
-func WithCallOverride(ctx stdctx.Context, f CallOverrideFunc) stdctx.Context {
+func WithCallOverride(ctx context.Context, f CallOverrideFunc) context.Context {
 	// We avoid appending to any existing call override
 	// so we don't risk overwriting a popped stack below.
 	var cofs []CallOverrideFunc
@@ -32,18 +32,18 @@ func WithCallOverride(ctx stdctx.Context, f CallOverrideFunc) stdctx.Context {
 		cofs = append(cofs, uf...)
 	}
 	cofs = append(cofs, f)
-	return stdctx.WithValue(ctx, &callOverrideKey, cofs)
+	return context.WithValue(ctx, &callOverrideKey, cofs)
 }
 
-func callOverrideFromContext(ctx stdctx.Context) (CallOverrideFunc, stdctx.Context, bool) {
+func callOverrideFromContext(ctx context.Context) (CallOverrideFunc, context.Context, bool) {
 	cofs, _ := ctx.Value(&callOverrideKey).([]CallOverrideFunc)
 	if len(cofs) == 0 {
 		return nil, nil, false
 	}
 	// We found a list of overrides; grab the last, and reconstitute a
-	// context that will hide it.
+	// aeContext that will hide it.
 	f := cofs[len(cofs)-1]
-	ctx = stdctx.WithValue(ctx, &callOverrideKey, cofs[:len(cofs)-1])
+	ctx = context.WithValue(ctx, &callOverrideKey, cofs[:len(cofs)-1])
 	return f, ctx, true
 }
 
@@ -51,35 +51,35 @@ type logOverrideFunc func(level int64, format string, args ...interface{})
 
 var logOverrideKey = "holds a logOverrideFunc"
 
-func WithLogOverride(ctx stdctx.Context, f logOverrideFunc) stdctx.Context {
-	return stdctx.WithValue(ctx, &logOverrideKey, f)
+func WithLogOverride(ctx context.Context, f logOverrideFunc) context.Context {
+	return context.WithValue(ctx, &logOverrideKey, f)
 }
 
 var appIDOverrideKey = "holds a string, being the full app ID"
 
-func WithAppIDOverride(ctx stdctx.Context, appID string) stdctx.Context {
-	return stdctx.WithValue(ctx, &appIDOverrideKey, appID)
+func WithAppIDOverride(ctx context.Context, appID string) context.Context {
+	return context.WithValue(ctx, &appIDOverrideKey, appID)
 }
 
 var apiHostOverrideKey = ctxKey("holds a string, being the alternate API_HOST")
 
-func withAPIHostOverride(ctx stdctx.Context, apiHost string) stdctx.Context {
-	return stdctx.WithValue(ctx, apiHostOverrideKey, apiHost)
+func withAPIHostOverride(ctx context.Context, apiHost string) context.Context {
+	return context.WithValue(ctx, apiHostOverrideKey, apiHost)
 }
 
 var apiPortOverrideKey = ctxKey("holds a string, being the alternate API_PORT")
 
-func withAPIPortOverride(ctx stdctx.Context, apiPort string) stdctx.Context {
-	return stdctx.WithValue(ctx, apiPortOverrideKey, apiPort)
+func withAPIPortOverride(ctx context.Context, apiPort string) context.Context {
+	return context.WithValue(ctx, apiPortOverrideKey, apiPort)
 }
 
 var namespaceKey = "holds the namespace string"
 
-func withNamespace(ctx stdctx.Context, ns string) stdctx.Context {
-	return stdctx.WithValue(ctx, &namespaceKey, ns)
+func withNamespace(ctx context.Context, ns string) context.Context {
+	return context.WithValue(ctx, &namespaceKey, ns)
 }
 
-func NamespaceFromContext(ctx stdctx.Context) string {
+func NamespaceFromContext(ctx context.Context) string {
 	// If there's no namespace, return the empty string.
 	ns, _ := ctx.Value(&namespaceKey).(string)
 	return ns
@@ -88,14 +88,14 @@ func NamespaceFromContext(ctx stdctx.Context) string {
 // FullyQualifiedAppID returns the fully-qualified application ID.
 // This may contain a partition prefix (e.g. "s~" for High Replication apps),
 // or a domain prefix (e.g. "example.com:").
-func FullyQualifiedAppID(ctx stdctx.Context) string {
+func FullyQualifiedAppID(ctx context.Context) string {
 	if id, ok := ctx.Value(&appIDOverrideKey).(string); ok {
 		return id
 	}
 	return fullyQualifiedAppID(ctx)
 }
 
-func Logf(ctx stdctx.Context, level int64, format string, args ...interface{}) {
+func Logf(ctx context.Context, level int64, format string, args ...interface{}) {
 	if f, ok := ctx.Value(&logOverrideKey).(logOverrideFunc); ok {
 		f(level, format, args...)
 		return
@@ -108,7 +108,7 @@ func Logf(ctx stdctx.Context, level int64, format string, args ...interface{}) {
 }
 
 // NamespacedContext wraps a Context to support namespaces.
-func NamespacedContext(ctx stdctx.Context, namespace string) stdctx.Context {
+func NamespacedContext(ctx context.Context, namespace string) context.Context {
 	return withNamespace(ctx, namespace)
 }
 

--- a/v2/internal/api_test.go
+++ b/v2/internal/api_test.go
@@ -7,7 +7,7 @@ package internal
 import (
 	"bufio"
 	"bytes"
-	netcontext "context"
+	stdctx "context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -230,7 +230,7 @@ func TestAPICallRPCFailure(t *testing.T) {
 	}
 	f.hang = make(chan int) // only for RunSlowly
 	for _, tc := range testCases {
-		ctx, _ := netcontext.WithTimeout(toContext(c), 100*time.Millisecond)
+		ctx, _ := stdctx.WithTimeout(toContext(c), 100*time.Millisecond)
 		err := Call(ctx, "errors", tc.method, &basepb.VoidProto{}, &basepb.VoidProto{})
 		ce, ok := err.(*CallError)
 		if !ok {
@@ -251,7 +251,7 @@ func TestAPICallDialFailure(t *testing.T) {
 	// This should time out quickly, not hang forever.
 	// We intentially don't set up the fakeAPIHandler for this test to cause the dail failure.
 	start := time.Now()
-	err := Call(netcontext.Background(), "foo", "bar", &basepb.VoidProto{}, &basepb.VoidProto{})
+	err := Call(stdctx.Background(), "foo", "bar", &basepb.VoidProto{}, &basepb.VoidProto{})
 	const max = 1 * time.Second
 	if taken := time.Since(start); taken > max {
 		t.Errorf("Dial hang took too long: %v > %v", taken, max)
@@ -340,7 +340,7 @@ func TestAPICallAllocations(t *testing.T) {
 	res := &basepb.StringProto{}
 	var apiErr error
 	avg := testing.AllocsPerRun(100, func() {
-		ctx, _ := netcontext.WithTimeout(toContext(c), 100*time.Millisecond)
+		ctx, _ := stdctx.WithTimeout(toContext(c), 100*time.Millisecond)
 		if err := Call(ctx, "actordb", "LookupActor", req, res); err != nil && apiErr == nil {
 			apiErr = err // get the first error only
 		}

--- a/v2/internal/api_test.go
+++ b/v2/internal/api_test.go
@@ -7,7 +7,7 @@ package internal
 import (
 	"bufio"
 	"bytes"
-	stdctx "context"
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -141,7 +141,7 @@ func (f *fakeAPIHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-func setup() (f *fakeAPIHandler, c *context, cleanup func()) {
+func setup() (f *fakeAPIHandler, c *aeContext, cleanup func()) {
 	f = &fakeAPIHandler{}
 	srv := httptest.NewServer(f)
 	u, err := url.Parse(srv.URL + apiPath)
@@ -152,7 +152,7 @@ func setup() (f *fakeAPIHandler, c *context, cleanup func()) {
 	if err != nil {
 		panic(fmt.Sprintf("url.Parse(%q): %v", srv.URL+apiPath, err))
 	}
-	return f, &context{
+	return f, &aeContext{
 			req: &http.Request{
 				Header: http.Header{
 					ticketHeader: []string{"s3cr3t"},
@@ -230,7 +230,7 @@ func TestAPICallRPCFailure(t *testing.T) {
 	}
 	f.hang = make(chan int) // only for RunSlowly
 	for _, tc := range testCases {
-		ctx, _ := stdctx.WithTimeout(toContext(c), 100*time.Millisecond)
+		ctx, _ := context.WithTimeout(toContext(c), 100*time.Millisecond)
 		err := Call(ctx, "errors", tc.method, &basepb.VoidProto{}, &basepb.VoidProto{})
 		ce, ok := err.(*CallError)
 		if !ok {
@@ -251,7 +251,7 @@ func TestAPICallDialFailure(t *testing.T) {
 	// This should time out quickly, not hang forever.
 	// We intentially don't set up the fakeAPIHandler for this test to cause the dail failure.
 	start := time.Now()
-	err := Call(stdctx.Background(), "foo", "bar", &basepb.VoidProto{}, &basepb.VoidProto{})
+	err := Call(context.Background(), "foo", "bar", &basepb.VoidProto{}, &basepb.VoidProto{})
 	const max = 1 * time.Second
 	if taken := time.Since(start); taken > max {
 		t.Errorf("Dial hang took too long: %v > %v", taken, max)
@@ -325,7 +325,7 @@ func TestAPICallAllocations(t *testing.T) {
 	// Run the test API server in a subprocess so we aren't counting its allocations.
 	cleanup := launchHelperProcess(t)
 	defer cleanup()
-	c := &context{
+	c := &aeContext{
 		req: &http.Request{
 			Header: http.Header{
 				ticketHeader: []string{"s3cr3t"},
@@ -340,7 +340,7 @@ func TestAPICallAllocations(t *testing.T) {
 	res := &basepb.StringProto{}
 	var apiErr error
 	avg := testing.AllocsPerRun(100, func() {
-		ctx, _ := stdctx.WithTimeout(toContext(c), 100*time.Millisecond)
+		ctx, _ := context.WithTimeout(toContext(c), 100*time.Millisecond)
 		if err := Call(ctx, "actordb", "LookupActor", req, res); err != nil && apiErr == nil {
 			apiErr = err // get the first error only
 		}

--- a/v2/internal/identity.go
+++ b/v2/internal/identity.go
@@ -5,7 +5,7 @@
 package internal
 
 import (
-	stdctx "context"
+	"context"
 	"log"
 	"net/http"
 	"os"
@@ -28,7 +28,7 @@ var (
 
 // AppID is the implementation of the wrapper function of the same name in
 // ../identity.go. See that file for commentary.
-func AppID(c stdctx.Context) string {
+func AppID(c context.Context) string {
 	return appID(FullyQualifiedAppID(c))
 }
 
@@ -57,7 +57,7 @@ func IsAppEngine() bool {
 	return IsStandard() || IsFlex()
 }
 
-func ctxHeaders(ctx stdctx.Context) http.Header {
+func ctxHeaders(ctx context.Context) http.Header {
 	c := fromContext(ctx)
 	if c == nil {
 		return nil
@@ -65,15 +65,15 @@ func ctxHeaders(ctx stdctx.Context) http.Header {
 	return c.Request().Header
 }
 
-func DefaultVersionHostname(ctx stdctx.Context) string {
+func DefaultVersionHostname(ctx context.Context) string {
 	return ctxHeaders(ctx).Get(hDefaultVersionHostname)
 }
 
-func RequestID(ctx stdctx.Context) string {
+func RequestID(ctx context.Context) string {
 	return ctxHeaders(ctx).Get(hRequestLogId)
 }
 
-func Datacenter(ctx stdctx.Context) string {
+func Datacenter(ctx context.Context) string {
 	if dc := ctxHeaders(ctx).Get(hDatacenter); dc != "" {
 		return dc
 	}
@@ -104,7 +104,7 @@ func ServerSoftware() string {
 
 // TODO(dsymonds): Remove the metadata fetches.
 
-func ModuleName(_ stdctx.Context) string {
+func ModuleName(_ context.Context) string {
 	if s := os.Getenv("GAE_MODULE_NAME"); s != "" {
 		return s
 	}
@@ -114,7 +114,7 @@ func ModuleName(_ stdctx.Context) string {
 	return string(mustGetMetadata("instance/attributes/gae_backend_name"))
 }
 
-func VersionID(_ stdctx.Context) string {
+func VersionID(_ context.Context) string {
 	if s1, s2 := os.Getenv("GAE_MODULE_VERSION"), os.Getenv("GAE_MINOR_VERSION"); s1 != "" && s2 != "" {
 		return s1 + "." + s2
 	}
@@ -149,7 +149,7 @@ func projectID() string {
 	return string(mustGetMetadata("instance/attributes/gae_project"))
 }
 
-func fullyQualifiedAppID(_ stdctx.Context) string {
+func fullyQualifiedAppID(_ context.Context) string {
 	if s := os.Getenv("GAE_APPLICATION"); s != "" {
 		return s
 	}

--- a/v2/internal/identity.go
+++ b/v2/internal/identity.go
@@ -5,7 +5,7 @@
 package internal
 
 import (
-	netcontext "context"
+	stdctx "context"
 	"log"
 	"net/http"
 	"os"
@@ -28,7 +28,7 @@ var (
 
 // AppID is the implementation of the wrapper function of the same name in
 // ../identity.go. See that file for commentary.
-func AppID(c netcontext.Context) string {
+func AppID(c stdctx.Context) string {
 	return appID(FullyQualifiedAppID(c))
 }
 
@@ -57,7 +57,7 @@ func IsAppEngine() bool {
 	return IsStandard() || IsFlex()
 }
 
-func ctxHeaders(ctx netcontext.Context) http.Header {
+func ctxHeaders(ctx stdctx.Context) http.Header {
 	c := fromContext(ctx)
 	if c == nil {
 		return nil
@@ -65,15 +65,15 @@ func ctxHeaders(ctx netcontext.Context) http.Header {
 	return c.Request().Header
 }
 
-func DefaultVersionHostname(ctx netcontext.Context) string {
+func DefaultVersionHostname(ctx stdctx.Context) string {
 	return ctxHeaders(ctx).Get(hDefaultVersionHostname)
 }
 
-func RequestID(ctx netcontext.Context) string {
+func RequestID(ctx stdctx.Context) string {
 	return ctxHeaders(ctx).Get(hRequestLogId)
 }
 
-func Datacenter(ctx netcontext.Context) string {
+func Datacenter(ctx stdctx.Context) string {
 	if dc := ctxHeaders(ctx).Get(hDatacenter); dc != "" {
 		return dc
 	}
@@ -104,7 +104,7 @@ func ServerSoftware() string {
 
 // TODO(dsymonds): Remove the metadata fetches.
 
-func ModuleName(_ netcontext.Context) string {
+func ModuleName(_ stdctx.Context) string {
 	if s := os.Getenv("GAE_MODULE_NAME"); s != "" {
 		return s
 	}
@@ -114,7 +114,7 @@ func ModuleName(_ netcontext.Context) string {
 	return string(mustGetMetadata("instance/attributes/gae_backend_name"))
 }
 
-func VersionID(_ netcontext.Context) string {
+func VersionID(_ stdctx.Context) string {
 	if s1, s2 := os.Getenv("GAE_MODULE_VERSION"), os.Getenv("GAE_MINOR_VERSION"); s1 != "" && s2 != "" {
 		return s1 + "." + s2
 	}
@@ -149,7 +149,7 @@ func projectID() string {
 	return string(mustGetMetadata("instance/attributes/gae_project"))
 }
 
-func fullyQualifiedAppID(_ netcontext.Context) string {
+func fullyQualifiedAppID(_ stdctx.Context) string {
 	if s := os.Getenv("GAE_APPLICATION"); s != "" {
 		return s
 	}

--- a/v2/internal/log.go
+++ b/v2/internal/log.go
@@ -26,9 +26,9 @@ var (
 	maxLogMessage = 255000
 )
 
-func logf(c *context, level int64, format string, args ...interface{}) {
+func logf(c *aeContext, level int64, format string, args ...interface{}) {
 	if c == nil {
-		panic("not an App Engine context")
+		panic("not an App Engine aeContext")
 	}
 
 	if !IsStandard() {
@@ -107,7 +107,7 @@ func chunkLog(msg string) []string {
 	return chunks
 }
 
-func traceAndSpan(c *context) (string, string) {
+func traceAndSpan(c *aeContext) (string, string) {
 	headers := c.req.Header["X-Cloud-Trace-Context"]
 	if len(headers) < 1 {
 		return "", ""

--- a/v2/internal/log_test.go
+++ b/v2/internal/log_test.go
@@ -430,7 +430,7 @@ func overrideMaxLogMessage(t *testing.T, max int) func() {
 	return func() { maxLogMessage = old }
 }
 
-func buildContextWithTraceHeaders(t *testing.T, headers []string) *context {
+func buildContextWithTraceHeaders(t *testing.T, headers []string) *aeContext {
 	t.Helper()
 	req, err := http.NewRequest("GET", "/", nil)
 	if err != nil {

--- a/v2/internal/net_test.go
+++ b/v2/internal/net_test.go
@@ -5,7 +5,7 @@
 package internal
 
 import (
-	stdctx "context"
+	"context"
 	"sync"
 	"testing"
 	"time"
@@ -42,7 +42,7 @@ func TestDialLimit(t *testing.T) {
 	}
 	time.Sleep(50 * time.Millisecond) // let those two RPCs start
 
-	ctx, _ := stdctx.WithTimeout(toContext(c), 50*time.Millisecond)
+	ctx, _ := context.WithTimeout(toContext(c), 50*time.Millisecond)
 	err := Call(ctx, "errors", "Non200", &basepb.VoidProto{}, &basepb.VoidProto{})
 	if err != errTimeout {
 		t.Errorf("Non200 RPC returned with err %v, want errTimeout", err)

--- a/v2/internal/net_test.go
+++ b/v2/internal/net_test.go
@@ -5,7 +5,7 @@
 package internal
 
 import (
-	netcontext "context"
+	stdctx "context"
 	"sync"
 	"testing"
 	"time"
@@ -42,7 +42,7 @@ func TestDialLimit(t *testing.T) {
 	}
 	time.Sleep(50 * time.Millisecond) // let those two RPCs start
 
-	ctx, _ := netcontext.WithTimeout(toContext(c), 50*time.Millisecond)
+	ctx, _ := stdctx.WithTimeout(toContext(c), 50*time.Millisecond)
 	err := Call(ctx, "errors", "Non200", &basepb.VoidProto{}, &basepb.VoidProto{})
 	if err != errTimeout {
 		t.Errorf("Non200 RPC returned with err %v, want errTimeout", err)

--- a/v2/internal/transaction.go
+++ b/v2/internal/transaction.go
@@ -7,7 +7,7 @@ package internal
 // This file implements hooks for applying datastore transactions.
 
 import (
-	netcontext "context"
+	stdctx "context"
 	"errors"
 	"reflect"
 
@@ -38,13 +38,13 @@ func applyTransaction(pb proto.Message, t *pb.Transaction) {
 
 var transactionKey = "used for *Transaction"
 
-func transactionFromContext(ctx netcontext.Context) *transaction {
+func transactionFromContext(ctx stdctx.Context) *transaction {
 	t, _ := ctx.Value(&transactionKey).(*transaction)
 	return t
 }
 
-func withTransaction(ctx netcontext.Context, t *transaction) netcontext.Context {
-	return netcontext.WithValue(ctx, &transactionKey, t)
+func withTransaction(ctx stdctx.Context, t *transaction) stdctx.Context {
+	return stdctx.WithValue(ctx, &transactionKey, t)
 }
 
 type transaction struct {
@@ -54,7 +54,7 @@ type transaction struct {
 
 var ErrConcurrentTransaction = errors.New("internal: concurrent transaction")
 
-func RunTransactionOnce(c netcontext.Context, f func(netcontext.Context) error, xg bool, readOnly bool, previousTransaction *pb.Transaction) (*pb.Transaction, error) {
+func RunTransactionOnce(c stdctx.Context, f func(stdctx.Context) error, xg bool, readOnly bool, previousTransaction *pb.Transaction) (*pb.Transaction, error) {
 	if transactionFromContext(c) != nil {
 		return nil, errors.New("nested transactions are not supported")
 	}

--- a/v2/internal/transaction.go
+++ b/v2/internal/transaction.go
@@ -7,7 +7,7 @@ package internal
 // This file implements hooks for applying datastore transactions.
 
 import (
-	stdctx "context"
+	"context"
 	"errors"
 	"reflect"
 
@@ -38,13 +38,13 @@ func applyTransaction(pb proto.Message, t *pb.Transaction) {
 
 var transactionKey = "used for *Transaction"
 
-func transactionFromContext(ctx stdctx.Context) *transaction {
+func transactionFromContext(ctx context.Context) *transaction {
 	t, _ := ctx.Value(&transactionKey).(*transaction)
 	return t
 }
 
-func withTransaction(ctx stdctx.Context, t *transaction) stdctx.Context {
-	return stdctx.WithValue(ctx, &transactionKey, t)
+func withTransaction(ctx context.Context, t *transaction) context.Context {
+	return context.WithValue(ctx, &transactionKey, t)
 }
 
 type transaction struct {
@@ -54,7 +54,7 @@ type transaction struct {
 
 var ErrConcurrentTransaction = errors.New("internal: concurrent transaction")
 
-func RunTransactionOnce(c stdctx.Context, f func(stdctx.Context) error, xg bool, readOnly bool, previousTransaction *pb.Transaction) (*pb.Transaction, error) {
+func RunTransactionOnce(c context.Context, f func(context.Context) error, xg bool, readOnly bool, previousTransaction *pb.Transaction) (*pb.Transaction, error) {
 	if transactionFromContext(c) != nil {
 		return nil, errors.New("nested transactions are not supported")
 	}

--- a/xmpp/xmpp.go
+++ b/xmpp/xmpp.go
@@ -27,11 +27,10 @@ To receive messages,
 package xmpp // import "google.golang.org/appengine/xmpp"
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
-
-	"golang.org/x/net/context"
 
 	"google.golang.org/appengine"
 	"google.golang.org/appengine/internal"


### PR DESCRIPTION
The golang.org/x/net/context package is an alias for stdlib context
since go1.7 (see https://go-review.googlesource.com/72570)

This patch replaces all uses of it for stdlib context.

The second commit renames the internal App Engine "context" type, so that
the import aliases can be removed; happy to either drop that commit, or
to squash it with the first one to reduce code-churn.
