### PR TITLE
Disable dev_appserver.py usage

### DIFF
--- a/.github/workflows/ci-v2.yaml
+++ b/.github/workflows/ci-v2.yaml
@@ -40,7 +40,9 @@ jobs:
         GO111MODULE: on
       run: |
         go get .
-        gcloud components install app-engine-python app-engine-go cloud-datastore-emulator app-engine-python-extras --quiet
+        # TODO(devappserver) Re-include app-engine-python and
+        # app-engine-python-extras once dev_appserver.py supports python3.
+        gcloud components install app-engine-go cloud-datastore-emulator --quiet
     - name: Test gomod v2
       env:
         GO111MODULE: on
@@ -86,7 +88,9 @@ jobs:
       run: |
         go get -u -v $(go list -f '{{join .Imports "\n"}}{{"\n"}}{{join .TestImports "\n"}}' ./... | sort | uniq | grep -v appengine)
         go get -u google.golang.org/appengine/v2
-        gcloud components install app-engine-python app-engine-go cloud-datastore-emulator app-engine-python-extras --quiet
+        # TODO(devappserver) Re-include app-engine-python and
+        # app-engine-python-extras once dev_appserver.py supports python3.
+        gcloud components install app-engine-go cloud-datastore-emulator --quiet
     - name: Test gopath v2
       working-directory: ${{env.working-directory}}
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,9 @@ jobs:
         GO111MODULE: on
       run: |
         go get .
-        gcloud components install app-engine-python app-engine-go cloud-datastore-emulator app-engine-python-extras --quiet
+        # TODO(devappserver) Re-include app-engine-python and
+        # app-engine-python-extras once dev_appserver.py supports python3.
+        gcloud components install app-engine-go cloud-datastore-emulator --quiet
     - name: Test gomod
       env:
         GO111MODULE: on
@@ -79,7 +81,9 @@ jobs:
       run: |
         go get -u -v $(go list -f '{{join .Imports "\n"}}{{"\n"}}{{join .TestImports "\n"}}' ./... | sort | uniq | grep -v appengine)
         go get -u google.golang.org/appengine
-        gcloud components install app-engine-python app-engine-go cloud-datastore-emulator app-engine-python-extras --quiet
+        # TODO(devappserver) Re-include app-engine-python and
+        # app-engine-python-extras once dev_appserver.py supports python3.
+        gcloud components install app-engine-go cloud-datastore-emulator --quiet
     - name: Test gopath
       run: |
         export APPENGINE_DEV_APPSERVER=$(which dev_appserver.py)


### PR DESCRIPTION
It seems like github actions switched to python3 because devappserver.py no longer runs, and complains with python2 not found.

https://github.blog/changelog/2020-02-27-github-actions-breaking-change-python-2-being-removed-from-all-virtual-environments/

https://github.com/actions/setup-python/issues/543#issuecomment-1319871808

python2 support will not be added to ubuntu 22.04, it seems.