### PR TITLE
Install Python2 in base image for DevAppServer tests and change test matrix for 1.11 and 1.20.x

### DIFF
--- a/.github/workflows/ci-v2.yaml
+++ b/.github/workflows/ci-v2.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [ '1.11.x', '1.12.x', '1.13.x', '1.14.x', '1.15.x', '1.16.x', '1.18.x', '1.19.x', '1.20.x']
+        go-version: [ '1.12.x', '1.13.x', '1.14.x', '1.15.x', '1.16.x', '1.18.x', '1.19.x', '1.20.x']
     env:
       working-directory: ./v2
 

--- a/.github/workflows/ci-v2.yaml
+++ b/.github/workflows/ci-v2.yaml
@@ -17,6 +17,10 @@ jobs:
       working-directory: ./v2
 
     steps:
+    - name: Update base image and intall Python2
+      run:  |
+       sudo apt-get update
+       sudo apt-get install -y python2 
     - name: Set up Go
       uses: actions/setup-go@v2
       with:

--- a/.github/workflows/ci-v2.yaml
+++ b/.github/workflows/ci-v2.yaml
@@ -66,6 +66,10 @@ jobs:
       working-directory: ./v2
     
     steps:
+    - name: Update base image and intall Python2
+      run:  |
+       sudo apt-get update
+       sudo apt-get install -y python2     
     - name: Set up Go
       uses: actions/setup-go@v2
       with:

--- a/.github/workflows/ci-v2.yaml
+++ b/.github/workflows/ci-v2.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [ '1.11.x', '1.12.x', '1.13.x', '1.14.x', '1.15.x', '1.16.x']
+        go-version: [ '1.11.x', '1.12.x', '1.13.x', '1.14.x', '1.15.x', '1.16.x', '1.18.x', '1.19.x', '1.20.x']
     env:
       working-directory: ./v2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,10 @@ jobs:
         go-version: [ '1.11.x', '1.12.x', '1.13.x', '1.14.x', '1.15.x', '1.16.x', '1.18.x', '1.19.x', '1.20.x']
 
     steps:
+    - name: Update base image and intall Python2
+      run:  |
+       sudo apt-get update
+       sudo apt-get install -y python2 
     - name: Set up Go
       uses: actions/setup-go@v2
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,10 @@ jobs:
         go-version: [ '1.11.x', '1.12.x']
 
     steps:
+    - name: Update base image and intall Python2
+      run:  |
+       sudo apt-get update
+       sudo apt-get install -y python2 
     - name: Set up Go
       uses: actions/setup-go@v2
       with:


### PR DESCRIPTION
Python2 has to be installed manually now on a latest Ubuntu image in order to be used by devappserver tests.
Also extended tests for Go 1.20 and remove a unsupported go 1.11 test.

Wit these changes all github testsactions are green. 