### PR TITLE
Fix the ci-update-workflow GitHub Actions

### DIFF
--- a/.github/workflows/ci-update-workflow.yml
+++ b/.github/workflows/ci-update-workflow.yml
@@ -4,6 +4,13 @@ on:
   schedule:
   # Run every day at 10AM.
   - cron: '0 10 * * *'
+  workflow_dispatch:
+    branches:
+    - master
+
+permissions:
+  repository-projects: write
+  pull-requests: write
 
 jobs:
   update-go-versions:


### PR DESCRIPTION
Fix the ci-update-workflow GitHub Actions:
1. Add `workflow_dispatch` to allow manually trigger the GitHub Actions.
2. Configure permissions for the `GITHUB_TOKEN` to be able to create the pull request - currently it's failing with an error https://github.com/golang/appengine/actions/runs/4509959366/jobs/7940335103