### PR TITLE
Extend the deadline of a test context to fix a timeout issue.

### DIFF
--- a/internal/api_test.go
+++ b/internal/api_test.go
@@ -235,7 +235,7 @@ func TestAPICallRPCFailure(t *testing.T) {
 	}
 	f.hang = make(chan int) // only for RunSlowly
 	for _, tc := range testCases {
-		ctx, _ := context.WithTimeout(toContext(c), 100*time.Millisecond)
+		ctx, _ := context.WithTimeout(toContext(c), 300*time.Millisecond)
 		err := Call(ctx, "errors", tc.method, &basepb.VoidProto{}, &basepb.VoidProto{})
 		ce, ok := err.(*CallError)
 		if !ok {

--- a/v2/internal/api_test.go
+++ b/v2/internal/api_test.go
@@ -212,7 +212,7 @@ func TestAPICallRPCFailure(t *testing.T) {
 	}
 	f.hang = make(chan int) // only for RunSlowly
 	for _, tc := range testCases {
-		ctx, _ := context.WithTimeout(r.Context(), 100*time.Millisecond)
+		ctx, _ := context.WithTimeout(r.Context(), 300*time.Millisecond)
 		err := Call(ctx, "errors", tc.method, &basepb.VoidProto{}, &basepb.VoidProto{})
 		ce, ok := err.(*CallError)
 		if !ok {


### PR DESCRIPTION
A sample timeout error can be found at https://github.com/golang/appengine/actions/runs/5524135326/jobs/10076013873. 