### PR TITLE
Replace deprecated command with environment file

### DIFF
--- a/.github/workflows/ci-update-workflow.yml
+++ b/.github/workflows/ci-update-workflow.yml
@@ -31,7 +31,7 @@ jobs:
         # Get all supported Go versions and pass the space-separated versions
         # string to the next step
         versions=$(gcloud functions runtimes list --format="value(NAME)" --project=gae-runtimes-private --region=us-west1 | grep ^go | tr '\n' ' ' | xargs)
-        echo "::set-output name=versions::$versions"
+        echo "versions=$versions" >> $GITHUB_OUTPUT
       id: get_versions
 
     - name: Checkout appengine repo


### PR DESCRIPTION
Signed-off-by: jongwooo <jongwooo.han@gmail.com>

## Description

Resolve #317 

Update `.github/workflows/ci-update-workflow.yml` to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow file that use `set-output` command through the following command:

```bash
$ find . -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
```

**AS-IS**

```yaml
echo "::set-output name=versions::$versions"
```

**TO-BE**

```yaml
echo "versions=$versions" >> $GITHUB_OUTPUT
```