### PR TITLE
[Automation] Update go-version matrix

### DIFF
--- a/.github/workflows/ci-v2.yaml
+++ b/.github/workflows/ci-v2.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: ['1.11.x', '1.13.x', '1.16.x', '1.18.x', '1.19.x', '1.20.x']
+        go-version: ['1.11.x', '1.13.x', '1.16.x', '1.18.x', '1.19.x', '1.20.x', '1.21.x']
     env:
       working-directory: ./v2
 


### PR DESCRIPTION
- go-version matrix updates

Update the go-version matrix in the CI workflows to include the new supported runtimes.

Auto-generated by https://github.com/chizhg/serverless-runtimes-automation/actions/runs/5901438099