### PR TITLE
blobstore: replace deprecated os seek consts with io ones

### DIFF
--- a/blobstore/blobstore_test.go
+++ b/blobstore/blobstore_test.go
@@ -13,7 +13,6 @@ import (
 	"mime/quotedprintable"
 	"net/http"
 	"net/textproto"
-	"os"
 	"strconv"
 	"strings"
 	"testing"
@@ -89,9 +88,9 @@ var readerTest = []struct {
 		{"Read", 1, 0, 0, "e", nil},
 		{"Read", 2, 0, 0, "fg", nil},
 		// Test Seek.
-		{"Seek", 0, 2, os.SEEK_SET, "2", nil},
+		{"Seek", 0, 2, io.SeekStart, "2", nil},
 		{"Read", 5, 0, 0, "cdefg", nil},
-		{"Seek", 0, 2, os.SEEK_CUR, "9", nil},
+		{"Seek", 0, 2, io.SeekCurrent, "9", nil},
 		{"Read", 1, 0, 0, "j", nil},
 		// Test reads up to and past EOF.
 		{"Read", 5, 0, 0, "klmno", nil},
@@ -106,7 +105,7 @@ var readerTest = []struct {
 	}},
 	{"a14p.1", []step{
 		// Test Seek before any reads.
-		{"Seek", 0, 2, os.SEEK_SET, "2", nil},
+		{"Seek", 0, 2, io.SeekStart, "2", nil},
 		{"Read", 1, 0, 0, "c", nil},
 		// Test that ReadAt doesn't affect the Read offset.
 		{"ReadAt", 3, 9, 0, "jkl", nil},
@@ -120,11 +119,11 @@ var readerTest = []struct {
 		// Test basic read.
 		{"Read", 1, 0, 0, "A", nil},
 		// Test that Read returns early when the buffer is exhausted.
-		{"Seek", 0, rbs - 2, os.SEEK_SET, strconv.Itoa(rbs - 2), nil},
+		{"Seek", 0, rbs - 2, io.SeekStart, strconv.Itoa(rbs - 2), nil},
 		{"Read", 5, 0, 0, "AA", nil},
 		{"Read", 3, 0, 0, "BBB", nil},
 		// Test that what we just read is still in the buffer.
-		{"Seek", 0, rbs - 2, os.SEEK_SET, strconv.Itoa(rbs - 2), nil},
+		{"Seek", 0, rbs - 2, io.SeekStart, strconv.Itoa(rbs - 2), nil},
 		{"Read", 5, 0, 0, "AABBB", nil},
 		// Test ReadAt.
 		{"ReadAt", 3, rbs - 4, 0, "AAA", nil},
@@ -133,7 +132,7 @@ var readerTest = []struct {
 		{"ReadAt", 5, rbs - 4, 0, "AAAAB", nil},
 		{"ReadAt", 2, rbs - 4, 0, "AA", nil},
 		// Test seeking backwards from the Read offset.
-		{"Seek", 0, 2*rbs - 8, os.SEEK_SET, strconv.Itoa(2*rbs - 8), nil},
+		{"Seek", 0, 2*rbs - 8, io.SeekStart, strconv.Itoa(2*rbs - 8), nil},
 		{"Read", 1, 0, 0, "B", nil},
 		{"Read", 1, 0, 0, "B", nil},
 		{"Read", 1, 0, 0, "B", nil},

--- a/blobstore/read.go
+++ b/blobstore/read.go
@@ -113,11 +113,11 @@ func (r *reader) Seek(offset int64, whence int) (ret int64, err error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	switch whence {
-	case os.SEEK_SET:
+	case io.SeekStart:
 		ret = offset
-	case os.SEEK_CUR:
+	case io.SeekCurrent:
 		ret = r.off + int64(r.r) + offset
-	case os.SEEK_END:
+	case io.SeekEnd:
 		return 0, errors.New("seeking relative to the end of a blob isn't supported")
 	default:
 		return 0, fmt.Errorf("invalid Seek whence value: %d", whence)

--- a/v2/blobstore/blobstore_test.go
+++ b/v2/blobstore/blobstore_test.go
@@ -13,7 +13,6 @@ import (
 	"mime/quotedprintable"
 	"net/http"
 	"net/textproto"
-	"os"
 	"strconv"
 	"strings"
 	"testing"
@@ -89,9 +88,9 @@ var readerTest = []struct {
 		{"Read", 1, 0, 0, "e", nil},
 		{"Read", 2, 0, 0, "fg", nil},
 		// Test Seek.
-		{"Seek", 0, 2, os.SEEK_SET, "2", nil},
+		{"Seek", 0, 2, io.SeekStart, "2", nil},
 		{"Read", 5, 0, 0, "cdefg", nil},
-		{"Seek", 0, 2, os.SEEK_CUR, "9", nil},
+		{"Seek", 0, 2, io.SeekCurrent, "9", nil},
 		{"Read", 1, 0, 0, "j", nil},
 		// Test reads up to and past EOF.
 		{"Read", 5, 0, 0, "klmno", nil},
@@ -106,7 +105,7 @@ var readerTest = []struct {
 	}},
 	{"a14p.1", []step{
 		// Test Seek before any reads.
-		{"Seek", 0, 2, os.SEEK_SET, "2", nil},
+		{"Seek", 0, 2, io.SeekStart, "2", nil},
 		{"Read", 1, 0, 0, "c", nil},
 		// Test that ReadAt doesn't affect the Read offset.
 		{"ReadAt", 3, 9, 0, "jkl", nil},
@@ -120,11 +119,11 @@ var readerTest = []struct {
 		// Test basic read.
 		{"Read", 1, 0, 0, "A", nil},
 		// Test that Read returns early when the buffer is exhausted.
-		{"Seek", 0, rbs - 2, os.SEEK_SET, strconv.Itoa(rbs - 2), nil},
+		{"Seek", 0, rbs - 2, io.SeekStart, strconv.Itoa(rbs - 2), nil},
 		{"Read", 5, 0, 0, "AA", nil},
 		{"Read", 3, 0, 0, "BBB", nil},
 		// Test that what we just read is still in the buffer.
-		{"Seek", 0, rbs - 2, os.SEEK_SET, strconv.Itoa(rbs - 2), nil},
+		{"Seek", 0, rbs - 2, io.SeekStart, strconv.Itoa(rbs - 2), nil},
 		{"Read", 5, 0, 0, "AABBB", nil},
 		// Test ReadAt.
 		{"ReadAt", 3, rbs - 4, 0, "AAA", nil},
@@ -133,7 +132,7 @@ var readerTest = []struct {
 		{"ReadAt", 5, rbs - 4, 0, "AAAAB", nil},
 		{"ReadAt", 2, rbs - 4, 0, "AA", nil},
 		// Test seeking backwards from the Read offset.
-		{"Seek", 0, 2*rbs - 8, os.SEEK_SET, strconv.Itoa(2*rbs - 8), nil},
+		{"Seek", 0, 2*rbs - 8, io.SeekStart, strconv.Itoa(2*rbs - 8), nil},
 		{"Read", 1, 0, 0, "B", nil},
 		{"Read", 1, 0, 0, "B", nil},
 		{"Read", 1, 0, 0, "B", nil},

--- a/v2/blobstore/read.go
+++ b/v2/blobstore/read.go
@@ -113,11 +113,11 @@ func (r *reader) Seek(offset int64, whence int) (ret int64, err error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	switch whence {
-	case os.SEEK_SET:
+	case io.SeekStart:
 		ret = offset
-	case os.SEEK_CUR:
+	case io.SeekCurrent:
 		ret = r.off + int64(r.r) + offset
-	case os.SEEK_END:
+	case io.SeekEnd:
 		return 0, errors.New("seeking relative to the end of a blob isn't supported")
 	default:
 		return 0, fmt.Errorf("invalid Seek whence value: %d", whence)


### PR DESCRIPTION
This PR replaces os constants with [io](https://pkg.go.dev/io@go1.11.13#pkg-constants):
- os.SEEK_SET with io.SeekStart
- os.SEEK_CUR with io.SeekCurrent
- os.SEEK_END with io.SeekEnd