### PR TITLE
datastore: clarify GetMulti documentation regarding partial loading behavior

### DIFF
--- a/datastore/datastore.go
+++ b/datastore/datastore.go
@@ -252,6 +252,10 @@ func Get(c context.Context, key *Key, dst interface{}) error {
 // As a special case, PropertyList is an invalid type for dst, even though a
 // PropertyList is a slice of structs. It is treated as invalid to avoid being
 // mistakenly passed when []PropertyList was intended.
+//
+// If any entity cannot be retrieved, GetMulti returns a MultiError. However,
+// successfully retrieved entities are still loaded into the corresponding dst elements,
+// even if a MultiError is returned.
 func GetMulti(c context.Context, key []*Key, dst interface{}) error {
 	v := reflect.ValueOf(dst)
 	multiArgType, _ := checkMultiArg(v)

--- a/v2/datastore/datastore.go
+++ b/v2/datastore/datastore.go
@@ -252,6 +252,10 @@ func Get(c context.Context, key *Key, dst interface{}) error {
 // As a special case, PropertyList is an invalid type for dst, even though a
 // PropertyList is a slice of structs. It is treated as invalid to avoid being
 // mistakenly passed when []PropertyList was intended.
+//
+// If any entity cannot be retrieved, GetMulti returns a MultiError. However,
+// successfully retrieved entities are still loaded into the corresponding dst elements,
+// even if a MultiError is returned.
 func GetMulti(c context.Context, key []*Key, dst interface{}) error {
 	v := reflect.ValueOf(dst)
 	multiArgType, _ := checkMultiArg(v)


### PR DESCRIPTION
I encountered a bug at Salesloft where we weren't properly handling entities that were successfully loaded when GetMulti returned a MultiError. The current documentation doesn't explicitly state that successful entities are still loaded into the destination slice even when errors occur with other entities.

This PR clarifies the documentation to make this behavior more apparent, which should hopefully help prevent similar issues..